### PR TITLE
SCALRCORE-16917: Use Revizor API to create test containers to run acceptance tests against

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -38,6 +38,17 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: "1.13"
+      - name: Environment settings
+        env:
+          API_BRANCH: ${{ contains(github.event.head_commit.message, '[API_BRANCH]') }}
+          DB_BRANCH: ${{ contains(github.event.head_commit.message, '[DB_BRANCH]') }}
+        run: |
+          echo "API_BRANCH=${API_BRANCH}" >> $GITHUB_ENV
+          echo "Set env variable from commit message: API_BRANCH=${API_BRANCH}"
+          echo "DB_BRANCH=${DB_BRANCH}" >> $GITHUB_ENV
+          echo "Set env variable from commit message: DB_BRANCH=${DB_BRANCH}"
+          echo BRANCH=${GITHUB_REF#refs/heads/} >> $GITHUB_ENV
+          echo "Set env variable: BRANCH=${GITHUB_REF#refs/heads/}"
       - name: Create container
         id: create
         uses: Scalr/gh-action-revizor@feature/SCALRCORE-16917
@@ -46,7 +57,7 @@ jobs:
       - name: Run acceptance tests
         env:
           SCALR_HOSTNAME: ${{ steps.create.outputs.hostname }}
-        run: make acc-tests
+        run: make testacc
       - name: Delete container
         id: delete
         if: ${{ steps.create.outputs.container_id }}

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -51,7 +51,7 @@ jobs:
           echo "Set env variable: BRANCH=${GITHUB_REF#refs/heads/}"
       - name: Create container
         id: create
-        uses: Scalr/gh-action-revizor@feature/SCALRCORE-16917
+        uses: Scalr/gh-action-revizor@master
         with:
           command: create
       - name: Run acceptance tests
@@ -61,7 +61,7 @@ jobs:
       - name: Delete container
         id: delete
         if: ${{ always() && steps.create.outputs.container_id }}
-        uses: Scalr/gh-action-revizor@feature/SCALRCORE-16917
+        uses: Scalr/gh-action-revizor@master
         with:
           command: delete
           container_id: ${{ steps.create.outputs.container_id }}

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -46,11 +46,10 @@ jobs:
       - name: Run acceptance tests
         env:
           SCALR_HOSTNAME: ${{ steps.create.outputs.hostname }}
-        run: |
-          printenv
+        run: make acc-tests
       - name: Delete container
         id: delete
-        if: ${{ always() }}
+        if: ${{ steps.create.outputs.container_id }}
         uses: Scalr/gh-action-revizor@feature/SCALRCORE-16917
         with:
           command: delete

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -15,8 +15,8 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.29
-  test:
-    name: test
+  unit-tests:
+    name: unit-tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -24,5 +24,34 @@ jobs:
         with:
           go-version: "1.13"
 
-      - name: unit tests
+      - name: Run unit tests
         run: make test
+  acc-tests:
+    runs-on: ubuntu-latest
+    name: acc-tests
+    env:
+      REVIZOR_URL: ${{ secrets.REVIZOR_URL }}
+      REVIZOR_TOKEN: ${{ secrets.REVIZOR_TOKEN }}
+      SCALR_TOKEN: ${{ secrets.SCALR_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.13"
+      - name: Create container
+        id: create
+        uses: Scalr/gh-action-revizor@feature/SCALRCORE-16917
+        with:
+          command: create
+      - name: Run acceptance tests
+        env:
+          SCALR_HOSTNAME: ${{ steps.create.outputs.hostname }}
+        run: |
+          printenv
+      - name: Delete container
+        id: delete
+        if: ${{ always() }}
+        uses: Scalr/gh-action-revizor@feature/SCALRCORE-16917
+        with:
+          command: delete
+          container_id: ${{ steps.create.outputs.container_id }}

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -60,7 +60,7 @@ jobs:
         run: make testacc
       - name: Delete container
         id: delete
-        if: ${{ steps.create.outputs.container_id }}
+        if: ${{ always() && steps.create.outputs.container_id }}
         uses: Scalr/gh-action-revizor@feature/SCALRCORE-16917
         with:
           command: delete

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,3 @@
-run:
-  tests: false
 linters:
   enable:
     - gofmt

--- a/README.md
+++ b/README.md
@@ -66,3 +66,21 @@ If you want to run one or more specific tests you can pass the targets as an env
 ```sh
 TESTARGS="-run TestAccScalrWorkspace_basic TestAccScalrWorkspace_update" make testacc
 ```
+
+### CI
+
+#### Acceptance tests
+
+To run tests with the container from the current branch. You need to specify branch flags in the commit message.
+Flags:
+- `[API_BRANCH]` - whether to use current branch as API branch.
+- `[DB_BRANCH]` - whether to use current branch as DB branch.
+
+For example, commit message:
+```
+Commit title
+
+Some description
+[API_BRANCH]
+[DB_BRANCH]
+```

--- a/scalr/data_source_endpoint_test.go
+++ b/scalr/data_source_endpoint_test.go
@@ -41,7 +41,7 @@ func testAccEndpointDataSourceConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource scalr_environment test {
   name       = "test-env-%[1]d"
-  account_id = "existing"
+  account_id = "acc-svrcncgh453bi8g"
 }
   
 resource scalr_endpoint test {

--- a/scalr/data_source_endpoint_test.go
+++ b/scalr/data_source_endpoint_test.go
@@ -53,5 +53,5 @@ resource scalr_endpoint test {
 
 data scalr_endpoint test {
   id         = scalr_endpoint.test.id
-}`, rInt, DefaultAccount)
+}`, rInt, defaultAccount)
 }

--- a/scalr/data_source_endpoint_test.go
+++ b/scalr/data_source_endpoint_test.go
@@ -41,7 +41,7 @@ func testAccEndpointDataSourceConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource scalr_environment test {
   name       = "test-env-%[1]d"
-  account_id = "acc-svrcncgh453bi8g"
+  account_id = "%s"
 }
   
 resource scalr_endpoint test {
@@ -53,5 +53,5 @@ resource scalr_endpoint test {
 
 data scalr_endpoint test {
   id         = scalr_endpoint.test.id
-}`, rInt)
+}`, rInt, DefaultAccount)
 }

--- a/scalr/data_source_environment_test.go
+++ b/scalr/data_source_environment_test.go
@@ -22,8 +22,8 @@ func TestAccEnvironmentDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.scalr_environment.test", "name", fmt.Sprintf("test-env-%d", rInt)),
 					resource.TestCheckResourceAttr("data.scalr_environment.test", "status", "Active"),
 					resource.TestCheckResourceAttr("data.scalr_environment.test", "cost_estimation_enabled", "false"),
-					resource.TestCheckResourceAttr("data.scalr_environment.test", "account_id", DefaultAccount),
-					resource.TestCheckResourceAttr("data.scalr_environment.test", "account_id", DefaultAccount),
+					resource.TestCheckResourceAttr("data.scalr_environment.test", "account_id", defaultAccount),
+					resource.TestCheckResourceAttr("data.scalr_environment.test", "account_id", defaultAccount),
 					resource.TestCheckResourceAttr("data.scalr_environment.test", "cloud_credentials.%", "0"),
 					resource.TestCheckResourceAttrSet("data.scalr_environment.test", "created_by.0.full_name"),
 					resource.TestCheckResourceAttrSet("data.scalr_environment.test", "created_by.0.email"),
@@ -43,5 +43,5 @@ resource "scalr_environment" "test" {
 
 data "scalr_environment" "test" {
   id         = scalr_environment.test.id
-}`, rInt, DefaultAccount)
+}`, rInt, defaultAccount)
 }

--- a/scalr/data_source_environment_test.go
+++ b/scalr/data_source_environment_test.go
@@ -22,8 +22,8 @@ func TestAccEnvironmentDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.scalr_environment.test", "name", fmt.Sprintf("test-env-%d", rInt)),
 					resource.TestCheckResourceAttr("data.scalr_environment.test", "status", "Active"),
 					resource.TestCheckResourceAttr("data.scalr_environment.test", "cost_estimation_enabled", "false"),
-					resource.TestCheckResourceAttr("data.scalr_environment.test", "account_id", "existing"),
-					resource.TestCheckResourceAttr("data.scalr_environment.test", "account_id", "existing"),
+					resource.TestCheckResourceAttr("data.scalr_environment.test", "account_id", "acc-svrcncgh453bi8g"),
+					resource.TestCheckResourceAttr("data.scalr_environment.test", "account_id", "acc-svrcncgh453bi8g"),
 					resource.TestCheckResourceAttr("data.scalr_environment.test", "cloud_credentials.%", "0"),
 					resource.TestCheckResourceAttrSet("data.scalr_environment.test", "created_by.0.full_name"),
 					resource.TestCheckResourceAttrSet("data.scalr_environment.test", "created_by.0.email"),
@@ -38,7 +38,7 @@ func testAccEnvironmentDataSourceConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "scalr_environment" "test" {
   name       = "test-env-%d"
-  account_id = "existing"
+  account_id = "acc-svrcncgh453bi8g"
 }
 
 data "scalr_environment" "test" {

--- a/scalr/data_source_environment_test.go
+++ b/scalr/data_source_environment_test.go
@@ -22,8 +22,8 @@ func TestAccEnvironmentDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.scalr_environment.test", "name", fmt.Sprintf("test-env-%d", rInt)),
 					resource.TestCheckResourceAttr("data.scalr_environment.test", "status", "Active"),
 					resource.TestCheckResourceAttr("data.scalr_environment.test", "cost_estimation_enabled", "false"),
-					resource.TestCheckResourceAttr("data.scalr_environment.test", "account_id", "acc-svrcncgh453bi8g"),
-					resource.TestCheckResourceAttr("data.scalr_environment.test", "account_id", "acc-svrcncgh453bi8g"),
+					resource.TestCheckResourceAttr("data.scalr_environment.test", "account_id", DefaultAccount),
+					resource.TestCheckResourceAttr("data.scalr_environment.test", "account_id", DefaultAccount),
 					resource.TestCheckResourceAttr("data.scalr_environment.test", "cloud_credentials.%", "0"),
 					resource.TestCheckResourceAttrSet("data.scalr_environment.test", "created_by.0.full_name"),
 					resource.TestCheckResourceAttrSet("data.scalr_environment.test", "created_by.0.email"),
@@ -38,10 +38,10 @@ func testAccEnvironmentDataSourceConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "scalr_environment" "test" {
   name       = "test-env-%d"
-  account_id = "acc-svrcncgh453bi8g"
+  account_id = "%s"
 }
 
 data "scalr_environment" "test" {
   id         = scalr_environment.test.id
-}`, rInt)
+}`, rInt, DefaultAccount)
 }

--- a/scalr/data_source_webhook_test.go
+++ b/scalr/data_source_webhook_test.go
@@ -37,7 +37,7 @@ func testAccWebhookDataSourceConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource scalr_environment test {
   name       = "test-env-%[1]d"
-  account_id = "existing"
+  account_id = "acc-svrcncgh453bi8g"
 }
   
 resource scalr_workspace test {

--- a/scalr/data_source_webhook_test.go
+++ b/scalr/data_source_webhook_test.go
@@ -37,7 +37,7 @@ func testAccWebhookDataSourceConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource scalr_environment test {
   name       = "test-env-%[1]d"
-  account_id = "acc-svrcncgh453bi8g"
+  account_id = "%s"
 }
   
 resource scalr_workspace test {
@@ -63,5 +63,5 @@ resource scalr_webhook test {
   
   data scalr_webhook test {
   id = scalr_webhook.test.id
-}`, rInt)
+}`, rInt, DefaultAccount)
 }

--- a/scalr/data_source_webhook_test.go
+++ b/scalr/data_source_webhook_test.go
@@ -63,5 +63,5 @@ resource scalr_webhook test {
   
   data scalr_webhook test {
   id = scalr_webhook.test.id
-}`, rInt, DefaultAccount)
+}`, rInt, defaultAccount)
 }

--- a/scalr/data_source_workspace_ids_test.go
+++ b/scalr/data_source_workspace_ids_test.go
@@ -75,7 +75,7 @@ func testAccScalrWorkspaceIDsDataSourceConfigBasic(rInt int) string {
 	return fmt.Sprintf(`
 resource scalr_environment test {
   name       = "test-env-%[1]d"
-  account_id = "acc-svrcncgh453bi8g"
+  account_id = "%s"
 }
 
 resource scalr_workspace foo {
@@ -96,14 +96,14 @@ resource scalr_workspace dummy {
 data scalr_workspace_ids foobar {
   names          = [scalr_workspace.foo.name, scalr_workspace.bar.name]
   environment_id = scalr_environment.test.id
-}`, rInt)
+}`, rInt, DefaultAccount)
 }
 
 func testAccScalrWorkspaceIDsDataSourceConfigWildcard(rInt int) string {
 	return fmt.Sprintf(`
 resource scalr_environment test {
   name       = "test-env-%[1]d"
-  account_id = "acc-svrcncgh453bi8g"
+  account_id = "%s"
 }
 
 resource scalr_workspace foo {
@@ -124,5 +124,5 @@ resource scalr_workspace dummy {
 data scalr_workspace_ids foobar {
   names          = ["*"]
   environment_id = scalr_environment.test.id
-}`, rInt)
+}`, rInt, DefaultAccount)
 }

--- a/scalr/data_source_workspace_ids_test.go
+++ b/scalr/data_source_workspace_ids_test.go
@@ -96,7 +96,7 @@ resource scalr_workspace dummy {
 data scalr_workspace_ids foobar {
   names          = [scalr_workspace.foo.name, scalr_workspace.bar.name]
   environment_id = scalr_environment.test.id
-}`, rInt, DefaultAccount)
+}`, rInt, defaultAccount)
 }
 
 func testAccScalrWorkspaceIDsDataSourceConfigWildcard(rInt int) string {
@@ -124,5 +124,5 @@ resource scalr_workspace dummy {
 data scalr_workspace_ids foobar {
   names          = ["*"]
   environment_id = scalr_environment.test.id
-}`, rInt, DefaultAccount)
+}`, rInt, defaultAccount)
 }

--- a/scalr/data_source_workspace_ids_test.go
+++ b/scalr/data_source_workspace_ids_test.go
@@ -99,6 +99,7 @@ data scalr_workspace_ids foobar {
 }`, rInt, defaultAccount)
 }
 
+// nolint:unused
 func testAccScalrWorkspaceIDsDataSourceConfigWildcard(rInt int) string {
 	return fmt.Sprintf(`
 resource scalr_environment test {

--- a/scalr/data_source_workspace_ids_test.go
+++ b/scalr/data_source_workspace_ids_test.go
@@ -75,7 +75,7 @@ func testAccScalrWorkspaceIDsDataSourceConfigBasic(rInt int) string {
 	return fmt.Sprintf(`
 resource scalr_environment test {
   name       = "test-env-%[1]d"
-  account_id = "existing"
+  account_id = "acc-svrcncgh453bi8g"
 }
 
 resource scalr_workspace foo {
@@ -103,7 +103,7 @@ func testAccScalrWorkspaceIDsDataSourceConfigWildcard(rInt int) string {
 	return fmt.Sprintf(`
 resource scalr_environment test {
   name       = "test-env-%[1]d"
-  account_id = "existing"
+  account_id = "acc-svrcncgh453bi8g"
 }
 
 resource scalr_workspace foo {

--- a/scalr/data_source_workspace_test.go
+++ b/scalr/data_source_workspace_test.go
@@ -42,7 +42,7 @@ func testAccScalrWorkspaceDataSourceConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource scalr_environment test {
   name       = "test-env-%[1]d"
-  account_id = "existing"
+  account_id = "acc-svrcncgh453bi8g"
 }
 
 resource scalr_workspace test {

--- a/scalr/data_source_workspace_test.go
+++ b/scalr/data_source_workspace_test.go
@@ -42,7 +42,7 @@ func testAccScalrWorkspaceDataSourceConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource scalr_environment test {
   name       = "test-env-%[1]d"
-  account_id = "acc-svrcncgh453bi8g"
+  account_id = "%s"
 }
 
 resource scalr_workspace test {
@@ -56,5 +56,5 @@ resource scalr_workspace test {
 data scalr_workspace test {
   name           = scalr_workspace.test.name
   environment_id = scalr_environment.test.id
-}`, rInt)
+}`, rInt, DefaultAccount)
 }

--- a/scalr/data_source_workspace_test.go
+++ b/scalr/data_source_workspace_test.go
@@ -56,5 +56,5 @@ resource scalr_workspace test {
 data scalr_workspace test {
   name           = scalr_workspace.test.name
   environment_id = scalr_environment.test.id
-}`, rInt, DefaultAccount)
+}`, rInt, defaultAccount)
 }

--- a/scalr/resource_scalr_endpoint_test.go
+++ b/scalr/resource_scalr_endpoint_test.go
@@ -84,7 +84,7 @@ func testAccEndpointConfig(rInt int, secretKey string) string {
 	return fmt.Sprintf(`
 resource scalr_environment test {
   name       = "test-env-%[1]d"
-  account_id = "existing"
+  account_id = "acc-svrcncgh453bi8g"
 }
 
 resource scalr_endpoint test {
@@ -101,7 +101,7 @@ func testAccEndpointConfigUpdate(rInt int, secretKey string) string {
 	return fmt.Sprintf(`
 resource scalr_environment test {
   name       = "test-env-%[1]d"
-  account_id = "existing"
+  account_id = "acc-svrcncgh453bi8g"
 }
 
 resource scalr_endpoint test {

--- a/scalr/resource_scalr_endpoint_test.go
+++ b/scalr/resource_scalr_endpoint_test.go
@@ -84,32 +84,32 @@ func testAccEndpointConfig(rInt int, secretKey string) string {
 	return fmt.Sprintf(`
 resource scalr_environment test {
   name       = "test-env-%[1]d"
-  account_id = "acc-svrcncgh453bi8g"
+  account_id = "%[2]s"
 }
 
 resource scalr_endpoint test {
   name         = "test endpoint-%[1]d"
-  secret_key   = "%s"
+  secret_key   = "%[3]s"
   timeout      = 15               
   max_attempts = 3                
   url          = "https://example.com/endpoint"
   environment_id = scalr_environment.test.id
-}`, rInt, secretKey)
+}`, rInt, DefaultAccount, secretKey)
 }
 
 func testAccEndpointConfigUpdate(rInt int, secretKey string) string {
 	return fmt.Sprintf(`
 resource scalr_environment test {
   name       = "test-env-%[1]d"
-  account_id = "acc-svrcncgh453bi8g"
+  account_id = "%[2]s"
 }
 
 resource scalr_endpoint test {
   name         = "test endpoint-%[1]d"
-  secret_key   = "%s"
+  secret_key   = "%[3]s"
   timeout      = 10               
   max_attempts = 5                
   url          = "https://example.com/endpoint-updated"
   environment_id = scalr_environment.test.id
-}`, rInt, secretKey)
+}`, rInt, DefaultAccount, secretKey)
 }

--- a/scalr/resource_scalr_endpoint_test.go
+++ b/scalr/resource_scalr_endpoint_test.go
@@ -94,7 +94,7 @@ resource scalr_endpoint test {
   max_attempts = 3                
   url          = "https://example.com/endpoint"
   environment_id = scalr_environment.test.id
-}`, rInt, DefaultAccount, secretKey)
+}`, rInt, defaultAccount, secretKey)
 }
 
 func testAccEndpointConfigUpdate(rInt int, secretKey string) string {
@@ -111,5 +111,5 @@ resource scalr_endpoint test {
   max_attempts = 5                
   url          = "https://example.com/endpoint-updated"
   environment_id = scalr_environment.test.id
-}`, rInt, DefaultAccount, secretKey)
+}`, rInt, defaultAccount, secretKey)
 }

--- a/scalr/resource_scalr_environment_test.go
+++ b/scalr/resource_scalr_environment_test.go
@@ -28,7 +28,7 @@ func TestAccEnvironment_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("scalr_environment.test", "name", fmt.Sprintf("test-env-%d", rInt)),
 					resource.TestCheckResourceAttr("scalr_environment.test", "cost_estimation_enabled", "true"),
 					resource.TestCheckResourceAttr("scalr_environment.test", "status", "Active"),
-					resource.TestCheckResourceAttr("scalr_environment.test", "account_id", "acc-svrcncgh453bi8g"),
+					resource.TestCheckResourceAttr("scalr_environment.test", "account_id", DefaultAccount),
 					resource.TestCheckResourceAttr("scalr_environment.test", "cloud_credentials.%", "0"),
 					resource.TestCheckResourceAttr("scalr_environment.test", "policy_groups.%", "0"),
 					resource.TestCheckResourceAttrSet("scalr_environment.test", "created_by.0.full_name"),
@@ -57,7 +57,7 @@ func TestAccEnvironment_update(t *testing.T) {
 					resource.TestCheckResourceAttr("scalr_environment.test", "name", fmt.Sprintf("test-env-%d", rInt)),
 					resource.TestCheckResourceAttr("scalr_environment.test", "cost_estimation_enabled", "true"),
 					resource.TestCheckResourceAttr("scalr_environment.test", "status", "Active"),
-					resource.TestCheckResourceAttr("scalr_environment.test", "account_id", "acc-svrcncgh453bi8g"),
+					resource.TestCheckResourceAttr("scalr_environment.test", "account_id", DefaultAccount),
 					resource.TestCheckResourceAttr("scalr_environment.test", "cloud_credentials.%", "0"),
 					resource.TestCheckResourceAttr("scalr_environment.test", "policy_groups.%", "0"),
 					resource.TestCheckResourceAttrSet("scalr_environment.test", "created_by.0.full_name"),
@@ -134,7 +134,7 @@ func testAccCheckScalrEnvironmentAttributes(environment *scalr.Environment, rInt
 		if environment.Name != fmt.Sprintf("test-env-%d", rInt) {
 			return fmt.Errorf("Bad name: %s", environment.Name)
 		}
-		if environment.Account.ID != "acc-svrcncgh453bi8g" {
+		if environment.Account.ID != DefaultAccount {
 			return fmt.Errorf("Bad account_id: %s", environment.Account.ID)
 		}
 
@@ -157,16 +157,16 @@ func testAccEnvironmentConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "scalr_environment" "test" {
   name       = "test-env-%d"
-  account_id = "acc-svrcncgh453bi8g"
+  account_id = "%s"
   cost_estimation_enabled = true
-}`, rInt)
+}`, rInt, DefaultAccount)
 }
 
 func testAccEnvironmentUpdateConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "scalr_environment" "test" {
   name       = "test-env-%d-patched"
-  account_id = "acc-svrcncgh453bi8g"
+  account_id = "%s"
   cost_estimation_enabled = false
-}`, rInt)
+}`, rInt, DefaultAccount)
 }

--- a/scalr/resource_scalr_environment_test.go
+++ b/scalr/resource_scalr_environment_test.go
@@ -28,7 +28,7 @@ func TestAccEnvironment_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("scalr_environment.test", "name", fmt.Sprintf("test-env-%d", rInt)),
 					resource.TestCheckResourceAttr("scalr_environment.test", "cost_estimation_enabled", "true"),
 					resource.TestCheckResourceAttr("scalr_environment.test", "status", "Active"),
-					resource.TestCheckResourceAttr("scalr_environment.test", "account_id", "existing"),
+					resource.TestCheckResourceAttr("scalr_environment.test", "account_id", "acc-svrcncgh453bi8g"),
 					resource.TestCheckResourceAttr("scalr_environment.test", "cloud_credentials.%", "0"),
 					resource.TestCheckResourceAttr("scalr_environment.test", "policy_groups.%", "0"),
 					resource.TestCheckResourceAttrSet("scalr_environment.test", "created_by.0.full_name"),
@@ -57,7 +57,7 @@ func TestAccEnvironment_update(t *testing.T) {
 					resource.TestCheckResourceAttr("scalr_environment.test", "name", fmt.Sprintf("test-env-%d", rInt)),
 					resource.TestCheckResourceAttr("scalr_environment.test", "cost_estimation_enabled", "true"),
 					resource.TestCheckResourceAttr("scalr_environment.test", "status", "Active"),
-					resource.TestCheckResourceAttr("scalr_environment.test", "account_id", "existing"),
+					resource.TestCheckResourceAttr("scalr_environment.test", "account_id", "acc-svrcncgh453bi8g"),
 					resource.TestCheckResourceAttr("scalr_environment.test", "cloud_credentials.%", "0"),
 					resource.TestCheckResourceAttr("scalr_environment.test", "policy_groups.%", "0"),
 					resource.TestCheckResourceAttrSet("scalr_environment.test", "created_by.0.full_name"),
@@ -134,7 +134,7 @@ func testAccCheckScalrEnvironmentAttributes(environment *scalr.Environment, rInt
 		if environment.Name != fmt.Sprintf("test-env-%d", rInt) {
 			return fmt.Errorf("Bad name: %s", environment.Name)
 		}
-		if environment.Account.ID != "existing" {
+		if environment.Account.ID != "acc-svrcncgh453bi8g" {
 			return fmt.Errorf("Bad account_id: %s", environment.Account.ID)
 		}
 
@@ -157,7 +157,7 @@ func testAccEnvironmentConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "scalr_environment" "test" {
   name       = "test-env-%d"
-  account_id = "existing"
+  account_id = "acc-svrcncgh453bi8g"
   cost_estimation_enabled = true
 }`, rInt)
 }
@@ -166,7 +166,7 @@ func testAccEnvironmentUpdateConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "scalr_environment" "test" {
   name       = "test-env-%d-patched"
-  account_id = "existing"
+  account_id = "acc-svrcncgh453bi8g"
   cost_estimation_enabled = false
 }`, rInt)
 }

--- a/scalr/resource_scalr_environment_test.go
+++ b/scalr/resource_scalr_environment_test.go
@@ -28,7 +28,7 @@ func TestAccEnvironment_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("scalr_environment.test", "name", fmt.Sprintf("test-env-%d", rInt)),
 					resource.TestCheckResourceAttr("scalr_environment.test", "cost_estimation_enabled", "true"),
 					resource.TestCheckResourceAttr("scalr_environment.test", "status", "Active"),
-					resource.TestCheckResourceAttr("scalr_environment.test", "account_id", DefaultAccount),
+					resource.TestCheckResourceAttr("scalr_environment.test", "account_id", defaultAccount),
 					resource.TestCheckResourceAttr("scalr_environment.test", "cloud_credentials.%", "0"),
 					resource.TestCheckResourceAttr("scalr_environment.test", "policy_groups.%", "0"),
 					resource.TestCheckResourceAttrSet("scalr_environment.test", "created_by.0.full_name"),
@@ -57,7 +57,7 @@ func TestAccEnvironment_update(t *testing.T) {
 					resource.TestCheckResourceAttr("scalr_environment.test", "name", fmt.Sprintf("test-env-%d", rInt)),
 					resource.TestCheckResourceAttr("scalr_environment.test", "cost_estimation_enabled", "true"),
 					resource.TestCheckResourceAttr("scalr_environment.test", "status", "Active"),
-					resource.TestCheckResourceAttr("scalr_environment.test", "account_id", DefaultAccount),
+					resource.TestCheckResourceAttr("scalr_environment.test", "account_id", defaultAccount),
 					resource.TestCheckResourceAttr("scalr_environment.test", "cloud_credentials.%", "0"),
 					resource.TestCheckResourceAttr("scalr_environment.test", "policy_groups.%", "0"),
 					resource.TestCheckResourceAttrSet("scalr_environment.test", "created_by.0.full_name"),
@@ -134,7 +134,7 @@ func testAccCheckScalrEnvironmentAttributes(environment *scalr.Environment, rInt
 		if environment.Name != fmt.Sprintf("test-env-%d", rInt) {
 			return fmt.Errorf("Bad name: %s", environment.Name)
 		}
-		if environment.Account.ID != DefaultAccount {
+		if environment.Account.ID != defaultAccount {
 			return fmt.Errorf("Bad account_id: %s", environment.Account.ID)
 		}
 
@@ -159,7 +159,7 @@ resource "scalr_environment" "test" {
   name       = "test-env-%d"
   account_id = "%s"
   cost_estimation_enabled = true
-}`, rInt, DefaultAccount)
+}`, rInt, defaultAccount)
 }
 
 func testAccEnvironmentUpdateConfig(rInt int) string {
@@ -168,5 +168,5 @@ resource "scalr_environment" "test" {
   name       = "test-env-%d-patched"
   account_id = "%s"
   cost_estimation_enabled = false
-}`, rInt, DefaultAccount)
+}`, rInt, defaultAccount)
 }

--- a/scalr/resource_scalr_variable_migrate_test.go
+++ b/scalr/resource_scalr_variable_migrate_test.go
@@ -1,6 +1,7 @@
 package scalr
 
 import (
+	"context"
 	"testing"
 
 	scalr "github.com/scalr/go-scalr"
@@ -21,7 +22,7 @@ func testResourceScalrVariableStateDataV1() map[string]interface{} {
 func TestResourceScalrVariableStateUpgradeV0(t *testing.T) {
 	client := testScalrClient(t)
 	name := "a-workspace"
-	client.Workspaces.Create(nil, scalr.WorkspaceCreateOptions{
+	client.Workspaces.Create(context.Background(), scalr.WorkspaceCreateOptions{
 		ID:          "ws-123",
 		Name:        &name,
 		Environment: &scalr.Environment{ID: "my-env"},

--- a/scalr/resource_scalr_variable_test.go
+++ b/scalr/resource_scalr_variable_test.go
@@ -231,7 +231,7 @@ resource scalr_workspace test {
 `
 
 func testAccScalrVariableBasic(rInt int) string {
-	return fmt.Sprintf(testAccScalrVariableCommonConfig, rInt, DefaultAccount, `
+	return fmt.Sprintf(testAccScalrVariableCommonConfig, rInt, defaultAccount, `
 resource scalr_variable test {
   key          = "key_test"
   value        = "value_test"
@@ -242,7 +242,7 @@ resource scalr_variable test {
 }
 
 func testAccScalrVariableBasicNonsensitive(rInt int) string {
-	return fmt.Sprintf(testAccScalrVariableCommonConfig, rInt, DefaultAccount, `
+	return fmt.Sprintf(testAccScalrVariableCommonConfig, rInt, defaultAccount, `
 resource scalr_variable test {
   key          = "key_test"
   value        = "value_test"
@@ -253,7 +253,7 @@ resource scalr_variable test {
 }
 
 func testAccScalrVariableUpdate(rInt int) string {
-	return fmt.Sprintf(testAccScalrVariableCommonConfig, rInt, DefaultAccount, `
+	return fmt.Sprintf(testAccScalrVariableCommonConfig, rInt, defaultAccount, `
 resource scalr_variable test {
   key          = "key_updated"
   value        = "value_updated"

--- a/scalr/resource_scalr_variable_test.go
+++ b/scalr/resource_scalr_variable_test.go
@@ -220,18 +220,18 @@ func testAccCheckScalrVariableDestroy(s *terraform.State) error {
 const testAccScalrVariableCommonConfig = `
 resource scalr_environment test {
   name       = "test-env-%[1]d"
-  account_id = "acc-svrcncgh453bi8g"
+  account_id = "%[2]s"
 }
   
 resource scalr_workspace test {
   name           = "test-ws-%[1]d"
   environment_id = scalr_environment.test.id
 }
-%s
+%[3]s
 `
 
 func testAccScalrVariableBasic(rInt int) string {
-	return fmt.Sprintf(testAccScalrVariableCommonConfig, rInt, `
+	return fmt.Sprintf(testAccScalrVariableCommonConfig, rInt, DefaultAccount, `
 resource scalr_variable test {
   key          = "key_test"
   value        = "value_test"
@@ -242,7 +242,7 @@ resource scalr_variable test {
 }
 
 func testAccScalrVariableBasicNonsensitive(rInt int) string {
-	return fmt.Sprintf(testAccScalrVariableCommonConfig, rInt, `
+	return fmt.Sprintf(testAccScalrVariableCommonConfig, rInt, DefaultAccount, `
 resource scalr_variable test {
   key          = "key_test"
   value        = "value_test"
@@ -253,7 +253,7 @@ resource scalr_variable test {
 }
 
 func testAccScalrVariableUpdate(rInt int) string {
-	return fmt.Sprintf(testAccScalrVariableCommonConfig, rInt, `
+	return fmt.Sprintf(testAccScalrVariableCommonConfig, rInt, DefaultAccount, `
 resource scalr_variable test {
   key          = "key_updated"
   value        = "value_updated"

--- a/scalr/resource_scalr_variable_test.go
+++ b/scalr/resource_scalr_variable_test.go
@@ -220,7 +220,7 @@ func testAccCheckScalrVariableDestroy(s *terraform.State) error {
 const testAccScalrVariableCommonConfig = `
 resource scalr_environment test {
   name       = "test-env-%[1]d"
-  account_id = "existing"
+  account_id = "acc-svrcncgh453bi8g"
 }
   
 resource scalr_workspace test {

--- a/scalr/resource_scalr_webhook_test.go
+++ b/scalr/resource_scalr_webhook_test.go
@@ -74,7 +74,7 @@ func testAccWebhookConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource scalr_environment test {
   name       = "test-env-%[1]d"
-  account_id = "acc-svrcncgh453bi8g"
+  account_id = "%s"
 }
   
 resource scalr_workspace test {
@@ -100,14 +100,14 @@ resource scalr_webhook test {
 
 data scalr_webhook test {
   id         = scalr_webhook.test.id
-}`, rInt)
+}`, rInt, DefaultAccount)
 }
 
 func testAccWebhookConfigUpdate(rInt int) string {
 	return fmt.Sprintf(`
 resource scalr_environment test {
   name       = "test-env-%[1]d"
-  account_id = "acc-svrcncgh453bi8g"
+  account_id = "%s"
 }
   
 resource scalr_workspace test {
@@ -133,5 +133,5 @@ resource scalr_webhook test {
 
 data scalr_webhook test {
   id         = scalr_webhook.test.id
-}`, rInt)
+}`, rInt, DefaultAccount)
 }

--- a/scalr/resource_scalr_webhook_test.go
+++ b/scalr/resource_scalr_webhook_test.go
@@ -100,7 +100,7 @@ resource scalr_webhook test {
 
 data scalr_webhook test {
   id         = scalr_webhook.test.id
-}`, rInt, DefaultAccount)
+}`, rInt, defaultAccount)
 }
 
 func testAccWebhookConfigUpdate(rInt int) string {
@@ -133,5 +133,5 @@ resource scalr_webhook test {
 
 data scalr_webhook test {
   id         = scalr_webhook.test.id
-}`, rInt, DefaultAccount)
+}`, rInt, defaultAccount)
 }

--- a/scalr/resource_scalr_webhook_test.go
+++ b/scalr/resource_scalr_webhook_test.go
@@ -74,7 +74,7 @@ func testAccWebhookConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource scalr_environment test {
   name       = "test-env-%[1]d"
-  account_id = "existing"
+  account_id = "acc-svrcncgh453bi8g"
 }
   
 resource scalr_workspace test {
@@ -107,7 +107,7 @@ func testAccWebhookConfigUpdate(rInt int) string {
 	return fmt.Sprintf(`
 resource scalr_environment test {
   name       = "test-env-%[1]d"
-  account_id = "existing"
+  account_id = "acc-svrcncgh453bi8g"
 }
   
 resource scalr_workspace test {

--- a/scalr/resource_scalr_workspace_test.go
+++ b/scalr/resource_scalr_workspace_test.go
@@ -344,13 +344,13 @@ func testAccCheckScalrWorkspaceDestroy(s *terraform.State) error {
 const testAccScalrWorkspaceCommonConfig = `
 resource scalr_environment test {
   name       = "test-env-%d"
-  account_id = "acc-svrcncgh453bi8g"
+  account_id = "%s"
 }
 %s
 `
 
 func testAccScalrWorkspaceBasic(rInt int) string {
-	return fmt.Sprintf(testAccScalrWorkspaceCommonConfig, rInt, `
+	return fmt.Sprintf(testAccScalrWorkspaceCommonConfig, rInt, DefaultAccount, `
 resource scalr_workspace test {
   name           = "workspace-test"
   environment_id = scalr_environment.test.id
@@ -359,7 +359,7 @@ resource scalr_workspace test {
 }
 
 func testAccScalrWorkspaceMonorepo(rInt int) string {
-	return fmt.Sprintf(testAccScalrWorkspaceCommonConfig, rInt, `
+	return fmt.Sprintf(testAccScalrWorkspaceCommonConfig, rInt, DefaultAccount, `
 resource "scalr_workspace" "test" {
   name                  = "workspace-monorepo"
   environment_id 		= scalr_environment.test.id
@@ -368,7 +368,7 @@ resource "scalr_workspace" "test" {
 }
 
 func testAccScalrWorkspaceRenamed(rInt int) string {
-	return fmt.Sprintf(testAccScalrWorkspaceCommonConfig, rInt, `
+	return fmt.Sprintf(testAccScalrWorkspaceCommonConfig, rInt, DefaultAccount, `
 resource "scalr_workspace" "test" {
   name           = "renamed-out-of-band"
   environment_id = scalr_environment.test.id
@@ -377,7 +377,7 @@ resource "scalr_workspace" "test" {
 }
 
 func testAccScalrWorkspaceUpdate(rInt int) string {
-	return fmt.Sprintf(testAccScalrWorkspaceCommonConfig, rInt, `
+	return fmt.Sprintf(testAccScalrWorkspaceCommonConfig, rInt, DefaultAccount, `
 resource "scalr_workspace" "test" {
   name                  = "workspace-updated"
   environment_id 		= scalr_environment.test.id

--- a/scalr/resource_scalr_workspace_test.go
+++ b/scalr/resource_scalr_workspace_test.go
@@ -350,7 +350,7 @@ resource scalr_environment test {
 `
 
 func testAccScalrWorkspaceBasic(rInt int) string {
-	return fmt.Sprintf(testAccScalrWorkspaceCommonConfig, rInt, DefaultAccount, `
+	return fmt.Sprintf(testAccScalrWorkspaceCommonConfig, rInt, defaultAccount, `
 resource scalr_workspace test {
   name           = "workspace-test"
   environment_id = scalr_environment.test.id
@@ -359,7 +359,7 @@ resource scalr_workspace test {
 }
 
 func testAccScalrWorkspaceMonorepo(rInt int) string {
-	return fmt.Sprintf(testAccScalrWorkspaceCommonConfig, rInt, DefaultAccount, `
+	return fmt.Sprintf(testAccScalrWorkspaceCommonConfig, rInt, defaultAccount, `
 resource "scalr_workspace" "test" {
   name                  = "workspace-monorepo"
   environment_id 		= scalr_environment.test.id
@@ -368,7 +368,7 @@ resource "scalr_workspace" "test" {
 }
 
 func testAccScalrWorkspaceRenamed(rInt int) string {
-	return fmt.Sprintf(testAccScalrWorkspaceCommonConfig, rInt, DefaultAccount, `
+	return fmt.Sprintf(testAccScalrWorkspaceCommonConfig, rInt, defaultAccount, `
 resource "scalr_workspace" "test" {
   name           = "renamed-out-of-band"
   environment_id = scalr_environment.test.id
@@ -377,7 +377,7 @@ resource "scalr_workspace" "test" {
 }
 
 func testAccScalrWorkspaceUpdate(rInt int) string {
-	return fmt.Sprintf(testAccScalrWorkspaceCommonConfig, rInt, DefaultAccount, `
+	return fmt.Sprintf(testAccScalrWorkspaceCommonConfig, rInt, defaultAccount, `
 resource "scalr_workspace" "test" {
   name                  = "workspace-updated"
   environment_id 		= scalr_environment.test.id

--- a/scalr/resource_scalr_workspace_test.go
+++ b/scalr/resource_scalr_workspace_test.go
@@ -344,7 +344,7 @@ func testAccCheckScalrWorkspaceDestroy(s *terraform.State) error {
 const testAccScalrWorkspaceCommonConfig = `
 resource scalr_environment test {
   name       = "test-env-%d"
-  account_id = "existing"
+  account_id = "acc-svrcncgh453bi8g"
 }
 %s
 `

--- a/scalr/testing.go
+++ b/scalr/testing.go
@@ -7,7 +7,7 @@ import (
 	scalr "github.com/scalr/go-scalr"
 )
 
-const DefaultAccount = "acc-svrcncgh453bi8g"
+const defaultAccount = "acc-svrcncgh453bi8g"
 
 func testScalrClient(t *testing.T) *scalr.Client {
 	config := &scalr.Config{

--- a/scalr/testing.go
+++ b/scalr/testing.go
@@ -7,6 +7,8 @@ import (
 	scalr "github.com/scalr/go-scalr"
 )
 
+const DefaultAccount = "acc-svrcncgh453bi8g"
+
 func testScalrClient(t *testing.T) *scalr.Client {
 	config := &scalr.Config{
 		Token: "not-a-token",

--- a/scalr/workspace_helpers_test.go
+++ b/scalr/workspace_helpers_test.go
@@ -1,6 +1,7 @@
 package scalr
 
 import (
+	"context"
 	"testing"
 
 	scalr "github.com/scalr/go-scalr"
@@ -31,7 +32,7 @@ func TestFetchWorkspaceID(t *testing.T) {
 
 	client := testScalrClient(t)
 	name := "a-workspace"
-	client.Workspaces.Create(nil, scalr.WorkspaceCreateOptions{
+	client.Workspaces.Create(context.Background(), scalr.WorkspaceCreateOptions{
 		ID:          "ws-123",
 		Name:        &name,
 		Environment: &scalr.Environment{ID: "hashicorp"},


### PR DESCRIPTION
Use Revizor API to create test containers to run acceptance tests against
SCALRCORE-16917

### Changelog
* [ ] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [ ] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
