### PR TITLE
SCALRCORE-20684 Provider > datasource scalr_role: make account_id optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `data.scalr_role`: argument `account_id` is now optional ([#97](https://github.com/Scalr/terraform-provider-scalr/pull/97))
+
 ## [1.0.0-rc24] - 2021-11-12
+
 - `data.scalr_webhook`: fixed broken webhook enabled filter ([#93](https://github.com/Scalr/terraform-provider-scalr/pull/93))
 
 ## [1.0.0-rc23] - 2021-11-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `data.scalr_role`: argument `account_id` is now optional ([#97](https://github.com/Scalr/terraform-provider-scalr/pull/97))
+- `data.scalr_role`: argument `account_id` is optional now ([#97](https://github.com/Scalr/terraform-provider-scalr/pull/97))
 
 ## [1.0.0-rc24] - 2021-11-12
 

--- a/docs/data-sources/scalr_role.md
+++ b/docs/data-sources/scalr_role.md
@@ -24,7 +24,7 @@ data "scalr_role" "example" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the role.
-* `account_id` - (Required) ID of the account, in the format `acc-<RANDOM STRING>`.
+* `account_id` - (Optional) ID of the account, in the format `acc-<RANDOM STRING>`.
 
 ## Attribute Reference
 

--- a/scalr/data_source_scalr_role.go
+++ b/scalr/data_source_scalr_role.go
@@ -23,7 +23,7 @@ func dataSourceScalrRole() *schema.Resource {
 			},
 			"account_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 
 			"is_system": {
@@ -50,9 +50,16 @@ func dataSourceScalrRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 	// required fields
 	name := d.Get("name").(string)
-	accountId := d.Get("account_id").(string)
 
-	options := scalr.RoleListOptions{Name: name, Account: scalr.String(accountId)}
+	options := scalr.RoleListOptions{Name: name}
+
+	var accountId interface{}
+	if accountId, ok := d.GetOk("account_id"); ok {
+		options.Account = scalr.String(accountId.(string))
+	} else {
+		accountId = "global"
+	}
+
 	log.Printf("[DEBUG] Read configuration of role: %s/%s", accountId, name)
 	roles, err := scalrClient.Roles.List(ctx, options)
 	if err != nil {

--- a/scalr/data_source_scalr_role.go
+++ b/scalr/data_source_scalr_role.go
@@ -53,11 +53,9 @@ func dataSourceScalrRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 	options := scalr.RoleListOptions{Name: name}
 
-	var accountId interface{}
+	var accountId interface{} = "global"
 	if accountId, ok := d.GetOk("account_id"); ok {
 		options.Account = scalr.String(accountId.(string))
-	} else {
-		accountId = "global"
 	}
 
 	log.Printf("[DEBUG] Read configuration of role: %s/%s", accountId, name)

--- a/scalr/data_source_scalr_role_test.go
+++ b/scalr/data_source_scalr_role_test.go
@@ -24,6 +24,12 @@ func TestAccScalrRoleDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.scalr_role.test", "account_id", defaultAccount),
 					resource.TestCheckResourceAttr("data.scalr_role.test", "permissions.0", "*:read"),
 					resource.TestCheckResourceAttr("data.scalr_role.test", "permissions.1", "roles:update"),
+
+					resource.TestCheckResourceAttr("data.scalr_role.user", "id", userRole),
+					resource.TestCheckResourceAttr("data.scalr_role.user", "name", "user"),
+					resource.TestCheckResourceAttrSet("data.scalr_role.user", "description"),
+					resource.TestCheckResourceAttr("data.scalr_role.user", "is_system", "true"),
+					resource.TestCheckNoResourceAttr("data.scalr_role.user", "account_id"),
 				),
 			},
 		},
@@ -62,7 +68,12 @@ resource "scalr_role" "test" {
 }
 
 data "scalr_role" "test" {
-	name = scalr_role.test.name
-	account_id = scalr_role.test.account_id
-}`, defaultAccount)
+  name       = scalr_role.test.name
+  account_id = scalr_role.test.account_id
+}
+
+data "scalr_role" "user" {
+    name = "user"
+}
+`, defaultAccount)
 }


### PR DESCRIPTION
### Changelog
* [x] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [x] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
