### PR TITLE
SCALRCORE-22362 Provider configuration > aws_external_id should not be required for role delegation credentials type if trusted entity type is service.

### DIFF
--- a/docs/resources/scalr_provider_configuration.md
+++ b/docs/resources/scalr_provider_configuration.md
@@ -21,8 +21,10 @@ resource "scalr_provider_configuration" "aws" {
   export_shell_variables = false
   environments           = [scalr_environment.env1.id]
   aws {
-    secret_key = "my-secret-key"
-    access_key = "my-access-key"
+    account_type     = "regular"
+    credentials_type = "access_keys"
+    secret_key       = "my-secret-key"
+    access_key       = "my-access-key"
   }
 }
 ```
@@ -106,7 +108,7 @@ resource "scalr_provider_configuration" "kubernetes" {
   * `credentials_type` - (Required) The type of AWS credentials, available options: `access_keys`, `role_delegation`.
   * `trusted_entity_type` - (Optional) Trusted entity type, available options: `aws_account`, `aws_service`. This option is required with `role_delegation` credentials type.
   * `role_arn` - (Optional) Amazon Resource Name (ARN) of the IAM Role to assume. This option is required with `role_delegation` credentials type.
-  * `external_id` - (Optional) External identifier to use when assuming the role. This option is required with `role_delegation` credentials type.
+  * `external_id` - (Optional) External identifier to use when assuming the role. This option is required with `role_delegation` credentials type and `aws_account` trusted entity type.
   * `secret_key` - (Optional) AWS secret key. This option is required with `access_keys` credentials type.
   * `access_key` - (Optional) AWS access key.This option is required with `access_keys` credentials type.
 * `google` - (Optional) Settings for the google provider configuraiton. Exactly one of the following attributes must be set: `aws`, `google`, `azurerm`, `scalr`, `custom`.

--- a/scalr/resource_scalr_provider_configuration.go
+++ b/scalr/resource_scalr_provider_configuration.go
@@ -262,8 +262,8 @@ func resourceScalrProviderConfigurationCreate(d *schema.ResourceData, meta inter
 			if len(*configurationOptions.AwsRoleArn) == 0 {
 				return fmt.Errorf("'role_arn' field is required for 'role_delegation' credentials type of aws provider configuration")
 			}
-			if len(*configurationOptions.AwsExternalId) == 0 {
-				return fmt.Errorf("'external_id' field is required for 'role_delegation' credentials type of aws provider configuration")
+			if *configurationOptions.AwsTrustedEntityType == "aws_account" && len(*configurationOptions.AwsExternalId) == 0 {
+				return fmt.Errorf("'external_id' field is required for 'role_delegation' credentials type with 'aws_account' trusted entity type of aws provider configuration")
 			}
 		} else if *configurationOptions.AwsCredentialsType != "access_keys" {
 			return fmt.Errorf("unknown aws provider configuration credentials type: %s, allowed: 'role_delegation', 'access_keys'", *configurationOptions.AwsCredentialsType)
@@ -519,8 +519,8 @@ func resourceScalrProviderConfigurationUpdate(d *schema.ResourceData, meta inter
 				if len(*configurationOptions.AwsRoleArn) == 0 {
 					return fmt.Errorf("'role_arn' field is required for 'role_delegation' credentials type of aws provider configuration")
 				}
-				if len(*configurationOptions.AwsExternalId) == 0 {
-					return fmt.Errorf("'external_id' field is required for 'role_delegation' credentials type of aws provider configuration")
+				if *configurationOptions.AwsTrustedEntityType == "aws_account" && len(*configurationOptions.AwsExternalId) == 0 {
+					return fmt.Errorf("'external_id' field is required for 'role_delegation' credentials type with 'aws_account' entity type of aws provider configuration")
 				}
 			} else if *configurationOptions.AwsCredentialsType != "access_keys" {
 				return fmt.Errorf("unknown aws provider configuration credentials type: %s, allowed: 'role_delegation', 'access_keys'", *configurationOptions.AwsCredentialsType)

--- a/scalr/resource_scalr_provider_configuration.go
+++ b/scalr/resource_scalr_provider_configuration.go
@@ -255,14 +255,17 @@ func resourceScalrProviderConfigurationCreate(d *schema.ResourceData, meta inter
 		if *configurationOptions.AwsCredentialsType == "role_delegation" {
 			configurationOptions.AwsTrustedEntityType = scalr.String(d.Get("aws.0.trusted_entity_type").(string))
 			configurationOptions.AwsRoleArn = scalr.String(d.Get("aws.0.role_arn").(string))
-			configurationOptions.AwsExternalId = scalr.String(d.Get("aws.0.external_id").(string))
+			externalIdI, externalIdExists := d.GetOk("aws.0.external_id")
+			if externalIdExists {
+				configurationOptions.AwsExternalId = scalr.String(externalIdI.(string))
+			}
 			if len(*configurationOptions.AwsTrustedEntityType) == 0 {
 				return fmt.Errorf("'trusted_entity_type' field is required for 'role_delegation' credentials type of aws provider configuration")
 			}
 			if len(*configurationOptions.AwsRoleArn) == 0 {
 				return fmt.Errorf("'role_arn' field is required for 'role_delegation' credentials type of aws provider configuration")
 			}
-			if *configurationOptions.AwsTrustedEntityType == "aws_account" && len(*configurationOptions.AwsExternalId) == 0 {
+			if *configurationOptions.AwsTrustedEntityType == "aws_account" && (!externalIdExists || (len(externalIdI.(string)) == 0)) {
 				return fmt.Errorf("'external_id' field is required for 'role_delegation' credentials type with 'aws_account' trusted entity type of aws provider configuration")
 			}
 		} else if *configurationOptions.AwsCredentialsType != "access_keys" {
@@ -512,14 +515,17 @@ func resourceScalrProviderConfigurationUpdate(d *schema.ResourceData, meta inter
 			if *configurationOptions.AwsCredentialsType == "role_delegation" {
 				configurationOptions.AwsTrustedEntityType = scalr.String(d.Get("aws.0.trusted_entity_type").(string))
 				configurationOptions.AwsRoleArn = scalr.String(d.Get("aws.0.role_arn").(string))
-				configurationOptions.AwsExternalId = scalr.String(d.Get("aws.0.external_id").(string))
+				externalIdI, externalIdExists := d.GetOk("aws.0.external_id")
+				if externalIdExists {
+					configurationOptions.AwsExternalId = scalr.String(externalIdI.(string))
+				}
 				if len(*configurationOptions.AwsTrustedEntityType) == 0 {
 					return fmt.Errorf("'trusted_entity_type' field is required for 'role_delegation' credentials type of aws provider configuration")
 				}
 				if len(*configurationOptions.AwsRoleArn) == 0 {
 					return fmt.Errorf("'role_arn' field is required for 'role_delegation' credentials type of aws provider configuration")
 				}
-				if *configurationOptions.AwsTrustedEntityType == "aws_account" && len(*configurationOptions.AwsExternalId) == 0 {
+				if *configurationOptions.AwsTrustedEntityType == "aws_account" && (!externalIdExists || (len(externalIdI.(string)) == 0)) {
 					return fmt.Errorf("'external_id' field is required for 'role_delegation' credentials type with 'aws_account' entity type of aws provider configuration")
 				}
 			} else if *configurationOptions.AwsCredentialsType != "access_keys" {


### PR DESCRIPTION
### Changelog
* [ ] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [ ] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
