### PR TITLE
SCALRCORE-22986 Provider > Non-empty plan with empty hooks for workspace

### DIFF
--- a/scalr/resource_scalr_workspace.go
+++ b/scalr/resource_scalr_workspace.go
@@ -3,10 +3,11 @@ package scalr
 import (
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
 	scalr "github.com/scalr/go-scalr"
 )
 
@@ -483,6 +484,14 @@ func resourceScalrWorkspaceRead(d *schema.ResourceData, meta interface{}) error 
 			"post_plan":  workspace.Hooks.PostPlan,
 			"pre_apply":  workspace.Hooks.PreApply,
 			"post_apply": workspace.Hooks.PostApply,
+		})
+	} else if _, ok := d.GetOk("hooks"); ok {
+		hooks = append(hooks, map[string]interface{}{
+			"pre_init":   "",
+			"pre_plan":   "",
+			"post_plan":  "",
+			"pre_apply":  "",
+			"post_apply": "",
 		})
 	}
 	d.Set("hooks", hooks)

--- a/scalr/resource_scalr_workspace_test.go
+++ b/scalr/resource_scalr_workspace_test.go
@@ -347,6 +347,21 @@ func TestAccScalrWorkspace_providerConfiguration(t *testing.T) {
 	})
 }
 
+func TestAccScalrWorkspace_emptyHooks(t *testing.T) {
+	rInt := GetRandomInteger()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckScalrWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccScalrWorkspaceEmptyHooks(rInt),
+			},
+		},
+	})
+}
+
 func testAccCheckScalrWorkspaceExists(
 	n string, workspace *scalr.Workspace) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -618,6 +633,21 @@ resource scalr_environment test {
 }
 %s
 `
+
+func testAccScalrWorkspaceEmptyHooks(rInt int) string {
+	return fmt.Sprintf(testAccScalrWorkspaceCommonConfig, rInt, defaultAccount, `
+resource scalr_workspace test {
+  name                   = "workspace-test"
+  environment_id         = scalr_environment.test.id
+  hooks {
+    pre_init   = ""
+    pre_plan   = ""
+    post_plan  = ""
+    pre_apply  = ""
+    post_apply = ""
+  }
+}`)
+}
 
 func testAccScalrWorkspaceBasic(rInt int) string {
 	return fmt.Sprintf(testAccScalrWorkspaceCommonConfig, rInt, defaultAccount, `


### PR DESCRIPTION
### Changelog
* [ ] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [ ] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
