### PR TITLE
SCALRCORE-25591 Provider > scalr_provider_configuration_default resource unlinks policy-groups and cloud creds from environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `scalr_provider_configuration_default` resource: fixed unlinking policy groups and cloud credentials from the environment by scalr_provider_configuration_default resource ([#216](https://github.com/Scalr/terraform-provider-scalr/pull/216))
+
 ## [1.0.2] - 2023-02-17
 
 ### Added

--- a/scalr/resource_scalr_provider_configuration_default.go
+++ b/scalr/resource_scalr_provider_configuration_default.go
@@ -91,6 +91,8 @@ func resourceScalrProviderConfigurationDefaultCreate(ctx context.Context, d *sch
 	environment.DefaultProviderConfigurations = append(environment.DefaultProviderConfigurations, &scalr.ProviderConfiguration{ID: providerConfiguration.ID})
 	updateOpts := scalr.EnvironmentUpdateOptions{
 		DefaultProviderConfigurations: environment.DefaultProviderConfigurations,
+		PolicyGroups:                  environment.PolicyGroups,
+		CloudCredentials:              environment.CloudCredentials,
 	}
 	_, err = scalrClient.Environments.Update(ctx, environment.ID, updateOpts)
 	if err != nil {
@@ -160,6 +162,8 @@ func resourceScalrProviderConfigurationDefaultDelete(ctx context.Context, d *sch
 
 	updateOpts := scalr.EnvironmentUpdateOptions{
 		DefaultProviderConfigurations: environment.DefaultProviderConfigurations,
+		PolicyGroups:                  environment.PolicyGroups,
+		CloudCredentials:              environment.CloudCredentials,
 	}
 
 	_, err = scalrClient.Environments.Update(ctx, environment.ID, updateOpts)


### PR DESCRIPTION
…on-default resource

### Changelog
* [x] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [ ] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
