### PR TITLE
Update registry name in makefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,8 +6,8 @@ BUILD_ENV=CGO_ENABLED=0
 TAG=$(shell PAGER= git tag --points-at HEAD)
 BRANCH=$(subst /,-,$(shell git branch --show-current))
 VERSION=$(if $(VER),$(VER),$(if $(TAG),$(TAG),$(BRANCH)))
-USER_PLUGIN_DIR_LINUX=${HOME}/.terraform.d/plugins/scalr.io/scalr/scalr/$(VERSION)/linux_amd64
-USER_PLUGIN_DIR=${HOME}/.terraform.d/plugins/scalr.io/scalr/scalr/$(VERSION)/$(PLATFORM)
+USER_PLUGIN_DIR_LINUX=${HOME}/.terraform.d/plugins/registry.scalr.io/scalr/scalr/$(VERSION)/linux_amd64
+USER_PLUGIN_DIR=${HOME}/.terraform.d/plugins/registry.scalr.io/scalr/scalr/$(VERSION)/$(PLATFORM)
 BIN_NAME := terraform-provider-scalr_$(VERSION)
 ARGS=-ldflags='-X github.com/scalr/terraform-provider-scalr/version.ProviderVersion=$(TAG) -X github.com/scalr/terraform-provider-scalr/version.Branch=$(BRANCH)'
 UPSTREAM_COMMIT_DESCRIPTION="Scalr terraform provider acceptance tests"


### PR DESCRIPTION
When installing a development version, the plugin currently gets copied to the plugin path `scalr.io/scalr/scalr`. However, the correct location (used by released versions and in the README) is `registry.scalr.io/scalr/scalr`. This change updates the makefile to install to a path that will be properly resolved in Terraform provider configurations.

### Changelog
* [ ] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [ ] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
