### PR TITLE
Match name exactly in data.scalr_vcs_provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `data.scalr_vcs_provider`: if the `name` argument is provided, it should match exactly instead of using a full-text search ([#222](https://github.com/Scalr/terraform-provider-scalr/pull/222))
+
 ## [1.0.4] - 2023-03-13
 
 ### Fixed


### PR DESCRIPTION
The name argument to the `scalr_vcs_provider` data source was being passed directly to the list operation in the Scalr API, which uses full-text search to filter its response.

This change keeps the same API logic, but adds an additional client-side filter to match the name exactly, similar to the filters used by the `scalr_webhook` and `scalr_endpoint` data sources.

It remains possible to omit the name argument as well (for example, if an account only has one GitHub provider configuration).

In our case, we had two GitHub VCS providers: one called `github-org` and another called `github-orgsub` and it was impossible to use this data source to retrieve the information on the former.

### Changelog
* [x] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [ ] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
