### PR TITLE
SCALRCORE-25909 Provider > scalr_workspace_run_schedule enables schedule for both apply and destroy even if only one is set in resource body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `data.scalr_environment`: optional `id` and `name` arguments can be used together ([#228](https://github.com/Scalr/terraform-provider-scalr/pull/228))
 - `data.scalr_endpoint`: optional `id` and `name` arguments can be used together ([#228](https://github.com/Scalr/terraform-provider-scalr/pull/228))
 - `data.scalr_service_account`: optional `id` and `email` arguments can be used together ([#228](https://github.com/Scalr/terraform-provider-scalr/pull/228))
+- `scalr_workscpace_run_schedule`: make `apply-schedule` and `destroy-schedule` attributes nullable ([#231](https://github.com/Scalr/terraform-provider-scalr/pull/231))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `data.scalr_environment`: optional `id` and `name` arguments can be used together ([#228](https://github.com/Scalr/terraform-provider-scalr/pull/228))
 - `data.scalr_endpoint`: optional `id` and `name` arguments can be used together ([#228](https://github.com/Scalr/terraform-provider-scalr/pull/228))
 - `data.scalr_service_account`: optional `id` and `email` arguments can be used together ([#228](https://github.com/Scalr/terraform-provider-scalr/pull/228))
-- `scalr_workscpace_run_schedule`: make `apply-schedule` and `destroy-schedule` attributes nullable ([#231](https://github.com/Scalr/terraform-provider-scalr/pull/231))
+- `scalr_workspace_run_schedule`: make `apply-schedule` and `destroy-schedule` attributes nullable ([#231](https://github.com/Scalr/terraform-provider-scalr/pull/231))
 
 ### Fixed
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734
-	github.com/scalr/go-scalr v0.0.0-20230403055927-2e9dae9e7852
+	github.com/scalr/go-scalr v0.0.0-20230410130137-d7f3a691d086
 )
 
 require (
@@ -60,3 +60,5 @@ require (
 )
 
 go 1.18
+
+replace github.com/scalr/go-scalr => /Users/roman/go/src/go-scalr

--- a/go.mod
+++ b/go.mod
@@ -60,5 +60,3 @@ require (
 )
 
 go 1.18
-
-replace github.com/scalr/go-scalr => /Users/roman/go/src/go-scalr

--- a/go.sum
+++ b/go.sum
@@ -244,6 +244,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/scalr/go-scalr v0.0.0-20230403055927-2e9dae9e7852 h1:2igC+Z9oxF5xuzrr4369cFH615VbYA4PnnST06KZvK0=
 github.com/scalr/go-scalr v0.0.0-20230403055927-2e9dae9e7852/go.mod h1:p34SHb25YRvbgft7SUjSDYESeoQhWzAlxGXId/BbaSE=
+github.com/scalr/go-scalr v0.0.0-20230410130137-d7f3a691d086 h1:2Ytrvt0ngrD1RT4OvntEDEMT5Yp46EhEuSdgA55wbFE=
+github.com/scalr/go-scalr v0.0.0-20230410130137-d7f3a691d086/go.mod h1:p34SHb25YRvbgft7SUjSDYESeoQhWzAlxGXId/BbaSE=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/scalr/go-scalr v0.0.0-20230403055927-2e9dae9e7852 h1:2igC+Z9oxF5xuzrr4369cFH615VbYA4PnnST06KZvK0=
-github.com/scalr/go-scalr v0.0.0-20230403055927-2e9dae9e7852/go.mod h1:p34SHb25YRvbgft7SUjSDYESeoQhWzAlxGXId/BbaSE=
 github.com/scalr/go-scalr v0.0.0-20230410130137-d7f3a691d086 h1:2Ytrvt0ngrD1RT4OvntEDEMT5Yp46EhEuSdgA55wbFE=
 github.com/scalr/go-scalr v0.0.0-20230410130137-d7f3a691d086/go.mod h1:p34SHb25YRvbgft7SUjSDYESeoQhWzAlxGXId/BbaSE=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=

--- a/scalr/resource_scalr_workspace_run_schedule.go
+++ b/scalr/resource_scalr_workspace_run_schedule.go
@@ -57,8 +57,8 @@ func resourceScalrWorkspaceRunScheduleCreate(ctx context.Context, d *schema.Reso
 	log.Printf(
 		"[DEBUG] Setting run schedules for workspace ID: %s, apply: %s, destroy: %s",
 		workspaceId,
-		options.ApplySchedule,
-		options.DestroySchedule,
+		*options.ApplySchedule,
+		*options.DestroySchedule,
 	)
 	workspace, err := scalrClient.Workspaces.SetSchedule(ctx, workspaceId, options)
 	if err != nil {
@@ -113,8 +113,8 @@ func resourceScalrWorkspaceRunScheduleUpdate(ctx context.Context, d *schema.Reso
 		log.Printf(
 			"[DEBUG] Setting run schedules for workspace ID: %s, apply: %s, destroy: %s",
 			workspaceId,
-			options.ApplySchedule,
-			options.DestroySchedule,
+			*options.ApplySchedule,
+			*options.DestroySchedule,
 		)
 		_, err = scalrClient.Workspaces.SetSchedule(ctx, workspaceId, options)
 		if err != nil {

--- a/scalr/resource_scalr_workspace_run_schedule.go
+++ b/scalr/resource_scalr_workspace_run_schedule.go
@@ -54,11 +54,21 @@ func resourceScalrWorkspaceRunScheduleCreate(ctx context.Context, d *schema.Reso
 		options.DestroySchedule = scalr.String(destroySchedule.(string))
 	}
 
+	applySchedule := ""
+	if options.ApplySchedule != nil {
+		applySchedule = *options.ApplySchedule
+	}
+
+	destroySchedule := ""
+	if options.DestroySchedule != nil {
+		destroySchedule = *options.DestroySchedule
+	}
+
 	log.Printf(
 		"[DEBUG] Setting run schedules for workspace ID: %s, apply: %s, destroy: %s",
 		workspaceId,
-		*options.ApplySchedule,
-		*options.DestroySchedule,
+		applySchedule,
+		destroySchedule,
 	)
 	workspace, err := scalrClient.Workspaces.SetSchedule(ctx, workspaceId, options)
 	if err != nil {
@@ -110,11 +120,20 @@ func resourceScalrWorkspaceRunScheduleUpdate(ctx context.Context, d *schema.Reso
 			options.DestroySchedule = scalr.String(destroySchedule.(string))
 		}
 
+		applySchedule := ""
+		if options.ApplySchedule != nil {
+			applySchedule = *options.ApplySchedule
+		}
+
+		destroySchedule := ""
+		if options.DestroySchedule != nil {
+			destroySchedule = *options.DestroySchedule
+		}
 		log.Printf(
 			"[DEBUG] Setting run schedules for workspace ID: %s, apply: %s, destroy: %s",
 			workspaceId,
-			*options.ApplySchedule,
-			*options.DestroySchedule,
+			applySchedule,
+			destroySchedule,
 		)
 		_, err = scalrClient.Workspaces.SetSchedule(ctx, workspaceId, options)
 		if err != nil {

--- a/scalr/resource_scalr_workspace_run_schedule.go
+++ b/scalr/resource_scalr_workspace_run_schedule.go
@@ -47,8 +47,12 @@ func resourceScalrWorkspaceRunScheduleCreate(ctx context.Context, d *schema.Reso
 	// Create a new options struct.
 	options := scalr.WorkspaceRunScheduleOptions{}
 
-	options.ApplySchedule = d.Get("apply_schedule").(string)
-	options.DestroySchedule = d.Get("destroy_schedule").(string)
+	if applySchedule, ok := d.GetOk("apply_schedule"); ok {
+		options.ApplySchedule = scalr.String(applySchedule.(string))
+	}
+	if destroySchedule, ok := d.GetOk("destroy_schedule"); ok {
+		options.DestroySchedule = scalr.String(destroySchedule.(string))
+	}
 
 	log.Printf(
 		"[DEBUG] Setting run schedules for workspace ID: %s, apply: %s, destroy: %s",
@@ -99,8 +103,12 @@ func resourceScalrWorkspaceRunScheduleUpdate(ctx context.Context, d *schema.Reso
 		// Create a new options struct.
 		options := scalr.WorkspaceRunScheduleOptions{}
 
-		options.ApplySchedule = d.Get("apply_schedule").(string)
-		options.DestroySchedule = d.Get("destroy_schedule").(string)
+		if applySchedule, ok := d.GetOk("apply_schedule"); ok {
+			options.ApplySchedule = scalr.String(applySchedule.(string))
+		}
+		if destroySchedule, ok := d.GetOk("destroy_schedule"); ok {
+			options.DestroySchedule = scalr.String(destroySchedule.(string))
+		}
 
 		log.Printf(
 			"[DEBUG] Setting run schedules for workspace ID: %s, apply: %s, destroy: %s",
@@ -122,8 +130,8 @@ func resourceScalrWorkspaceRunScheduleDelete(ctx context.Context, d *schema.Reso
 
 	log.Printf("[DEBUG] Delete run schedules for workspace: %s", d.Id())
 	_, err := scalrClient.Workspaces.SetSchedule(ctx, d.Id(), scalr.WorkspaceRunScheduleOptions{
-		ApplySchedule:   "",
-		DestroySchedule: "",
+		ApplySchedule:   nil,
+		DestroySchedule: nil,
 	})
 	if err != nil {
 		if errors.Is(err, scalr.ErrResourceNotFound) {


### PR DESCRIPTION
### Changelog
* [x] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [ ] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
