### PR TITLE
SCALRCORE-26425 Provider > data.scalr_role: allow search global roles without account_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `data.scalr_module_version`: if there are several module versions with the same version, select the version that has the 'is-root-module' flag set to true. ([#229](https://github.com/Scalr/terraform-provider-scalr/pull/229))
+- `data.scalr_role`: do not require default value for `account_id` to be present in run environment when searching for a system role. ([#241](https://github.com/Scalr/terraform-provider-scalr/pull/241))
 
 ### Required
 

--- a/scalr/data_source_scalr_role.go
+++ b/scalr/data_source_scalr_role.go
@@ -32,7 +32,7 @@ func dataSourceScalrRole() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				DefaultFunc: scalrAccountIDDefaultFunc,
+				DefaultFunc: scalrAccountIDOptionalDefaultFunc,
 			},
 
 			"is_system": {

--- a/scalr/helpers.go
+++ b/scalr/helpers.go
@@ -174,6 +174,8 @@ func getDefaultScalrAccountID() (string, bool) {
 	return "", false
 }
 
+// scalrAccountIDDefaultFunc is a schema.SchemaDefaultFunc that returns default account id.
+// If account info is not present, the error is returned.
 func scalrAccountIDDefaultFunc() (interface{}, error) {
 	if accID, ok := getDefaultScalrAccountID(); ok {
 		return accID, nil
@@ -181,4 +183,12 @@ func scalrAccountIDDefaultFunc() (interface{}, error) {
 	return nil, errors.New("Default value for `account_id` could not be computed." +
 		"\nIf you are using Scalr Provider for local runs, please set the attribute in resources explicitly," +
 		"\nor export `SCALR_ACCOUNT_ID` environment variable prior the run.")
+}
+
+// scalrAccountIDOptionalDefaultFunc is a schema.SchemaDefaultFunc that returns default account id
+// or an empty (string) value, if account info is not present.
+// Never returns non-nil error.
+func scalrAccountIDOptionalDefaultFunc() (interface{}, error) {
+	accID, _ := getDefaultScalrAccountID()
+	return accID, nil
 }

--- a/scalr/resource_scalr_webhook.go
+++ b/scalr/resource_scalr_webhook.go
@@ -131,7 +131,7 @@ func resourceScalrWebhook() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				DefaultFunc: webhookAccountIDDefaultFunc,
+				DefaultFunc: scalrAccountIDOptionalDefaultFunc,
 				ForceNew:    true,
 			},
 
@@ -172,14 +172,6 @@ func forceRecreateIf() schema.CustomizeDiffFunc {
 		}
 		return nil
 	}
-}
-
-// webhookAccountIDDefaultFunc returns default account id, if present.
-// It won't return an error, as `account_id` is optional and computed
-// for old-style webhooks.
-func webhookAccountIDDefaultFunc() (interface{}, error) {
-	accID, _ := getDefaultScalrAccountID()
-	return accID, nil
 }
 
 // remove after https://scalr-labs.atlassian.net/browse/SCALRCORE-16234


### PR DESCRIPTION
### Changelog
* [x] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [ ] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
