### PR TITLE
SCALRCORE-27104 Provider configurations: Allow built-in providers to …

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734
-	github.com/scalr/go-scalr v0.0.0-20230612172707-84e1dfe6bf84
+	github.com/scalr/go-scalr v0.0.0-20230615080911-2a65ba6564fc
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/scalr/go-scalr v0.0.0-20230612172707-84e1dfe6bf84 h1:YWMFr3mzpTvLKjgC3Hdgtzr+yzyVBLjO7ryp+Gma6dM=
-github.com/scalr/go-scalr v0.0.0-20230612172707-84e1dfe6bf84/go.mod h1:p34SHb25YRvbgft7SUjSDYESeoQhWzAlxGXId/BbaSE=
+github.com/scalr/go-scalr v0.0.0-20230615080911-2a65ba6564fc h1:JNOpJ7ASeCOkp6UKfNWAVhJ6e6anJ65W7m5oGUpTR78=
+github.com/scalr/go-scalr v0.0.0-20230615080911-2a65ba6564fc/go.mod h1:p34SHb25YRvbgft7SUjSDYESeoQhWzAlxGXId/BbaSE=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=

--- a/scalr/resource_scalr_provider_configuration.go
+++ b/scalr/resource_scalr_provider_configuration.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/scalr/go-scalr"

--- a/scalr/resource_scalr_provider_configuration_test.go
+++ b/scalr/resource_scalr_provider_configuration_test.go
@@ -153,6 +153,26 @@ func TestAccProviderConfiguration_custom(t *testing.T) {
 	})
 }
 
+func TestAccProviderConfiguration_aws_custom(t *testing.T) {
+	var providerConfiguration scalr.ProviderConfiguration
+	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckProviderConfigurationResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccScalrProviderConfigurationCustomConfiAws(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProviderConfigurationExists("scalr_provider_configuration.custom_aws", &providerConfiguration),
+					testAccCheckProviderConfigurationCustomAwsValues(&providerConfiguration, rName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccProviderConfiguration_aws(t *testing.T) {
 	var providerConfiguration scalr.ProviderConfiguration
 	rName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
@@ -432,6 +452,21 @@ func testAccCheckProviderConfigurationAwsValues(providerConfiguration *scalr.Pro
 		}
 		if providerConfiguration.AwsAccountType != "regular" {
 			return fmt.Errorf("bad aws account type, expected \"%s\", got: %#v", "regular", providerConfiguration.AwsAccountType)
+		}
+		return nil
+	}
+}
+
+func testAccCheckProviderConfigurationCustomAwsValues(providerConfiguration *scalr.ProviderConfiguration, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if providerConfiguration.Name != name {
+			return fmt.Errorf("bad name, expected \"%s\", got: %#v", name, providerConfiguration.Name)
+		}
+		if providerConfiguration.ProviderName != "aws" {
+			return fmt.Errorf("bad provider type, expected \"%s\", got: %#v", "aws", providerConfiguration.ProviderName)
+		}
+		if !providerConfiguration.IsCustom {
+			return fmt.Errorf("bad is-custom attr, expected \"%s\", got: %#v", "aws", providerConfiguration.IsCustom)
 		}
 		return nil
 	}
@@ -719,6 +754,30 @@ resource "scalr_provider_configuration" "kubernetes" {
     argument {
       name  = "username"
       value = "my-username"
+    }
+  }
+}
+`, defaultAccount, name, defaultAccount)
+}
+
+func testAccScalrProviderConfigurationCustomConfiAws(name string) string {
+	return fmt.Sprintf(`
+resource "scalr_environment" "test" {
+  name                    = "test-provider-configuration-env"
+  account_id              = "%s"
+  cost_estimation_enabled = false
+}
+
+resource "scalr_provider_configuration" "custom_aws" {
+  name         = "%s"
+  account_id   = "%s"
+  environments = ["${scalr_environment.test.id}"]
+  custom {
+    provider_name = "aws"
+    argument {
+      name        = "region"
+      value       = "us-east-1"
+      sensitive   = false
     }
   }
 }

--- a/scalr/resource_scalr_provider_configuration_test.go
+++ b/scalr/resource_scalr_provider_configuration_test.go
@@ -163,7 +163,7 @@ func TestAccProviderConfiguration_aws_custom(t *testing.T) {
 		CheckDestroy:      testAccCheckProviderConfigurationResourceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScalrProviderConfigurationCustomConfiAws(rName),
+				Config: testAccScalrProviderConfigurationCustomConfigAws(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProviderConfigurationExists("scalr_provider_configuration.custom_aws", &providerConfiguration),
 					testAccCheckProviderConfigurationCustomAwsValues(&providerConfiguration, rName),
@@ -760,7 +760,7 @@ resource "scalr_provider_configuration" "kubernetes" {
 `, defaultAccount, name, defaultAccount)
 }
 
-func testAccScalrProviderConfigurationCustomConfiAws(name string) string {
+func testAccScalrProviderConfigurationCustomConfigAws(name string) string {
 	return fmt.Sprintf(`
 resource "scalr_environment" "test" {
   name                    = "test-provider-configuration-env"


### PR DESCRIPTION
…be registered as custom.[API_BRANCH]

### Changelog
* [ ] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [ ] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
