### PR TITLE
SCALRCORE-27528 Provider > error doesn't contain 'oidc' when applying run with wrong credentials_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `scalr_provider_configuration`: Fix error message if aws credentials type is wrong.
+
 ## [1.4.0] - 2023-08-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `scalr_provider_configuration`: Fix error message if aws credentials type is wrong.
+- `scalr_provider_configuration`: Fix error message if aws credentials type is wrong. ([#275](https://github.com/Scalr/terraform-provider-scalr/pull/275))
 
 ## [1.4.0] - 2023-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `scalr_provider_configuration`: Fix error message if aws credentials type is wrong. ([#275](https://github.com/Scalr/terraform-provider-scalr/pull/275))
+- `scalr_provider_configuration`: Fixed error message if aws credentials type is wrong. ([#275](https://github.com/Scalr/terraform-provider-scalr/pull/275))
 
 ## [1.4.0] - 2023-08-11
 

--- a/scalr/resource_scalr_provider_configuration.go
+++ b/scalr/resource_scalr_provider_configuration.go
@@ -310,7 +310,7 @@ func resourceScalrProviderConfigurationCreate(ctx context.Context, d *schema.Res
 				return diag.Errorf("'audience' field is required for 'oidc' credentials type of aws provider configuration")
 			}
 		} else if *configurationOptions.AwsCredentialsType != "access_keys" {
-			return diag.Errorf("unknown aws provider configuration credentials type: %s, allowed: 'role_delegation', 'access_keys'", *configurationOptions.AwsCredentialsType)
+			return diag.Errorf("unknown aws provider configuration credentials type: %s, allowed: 'role_delegation', 'access_keys', 'oidc'", *configurationOptions.AwsCredentialsType)
 		} else if !accessKeyIdExists || !accessSecretKeyExists {
 			return diag.Errorf("'access_key' and 'secret_key' fields are required for 'access_keys' credentials type of aws provider configuration")
 		}
@@ -679,7 +679,7 @@ func resourceScalrProviderConfigurationUpdate(ctx context.Context, d *schema.Res
 					return diag.Errorf("'audience' field is required for 'oidc' credentials type of aws provider configuration")
 				}
 			} else if *configurationOptions.AwsCredentialsType != "access_keys" {
-				return diag.Errorf("unknown aws provider configuration credentials type: %s, allowed: 'role_delegation', 'access_keys'", *configurationOptions.AwsCredentialsType)
+				return diag.Errorf("unknown aws provider configuration credentials type: %s, allowed: 'role_delegation', 'access_keys', 'oidc'", *configurationOptions.AwsCredentialsType)
 			} else if !accessKeyIdExists || !accessSecretKeyExists {
 				return diag.Errorf("'access_key' and 'secret_key' fields are required for 'access_keys' credentials type of aws provider configuration")
 			}


### PR DESCRIPTION
### Changelog
* [ ] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [ ] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
