### PR TITLE
SCALRCORE-27107 Provider > Add `default_provider_configurations` to the `scalr_environment` data block outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `scalr_provider_configuration`: Fixed error message if aws credentials type is wrong. ([#275](https://github.com/Scalr/terraform-provider-scalr/pull/275))
+- `data.scalr_enviroment`: Added new attribute `default_provider_configurations` ([#279](https://github.com/Scalr/terraform-provider-scalr/pull/279))
 
 ## [1.4.0] - 2023-08-11
 

--- a/docs/data-sources/environment.md
+++ b/docs/data-sources/environment.md
@@ -37,6 +37,7 @@ data "scalr_environment" "example2" {
 
 - `cost_estimation_enabled` (Boolean) Boolean indicates if cost estimation is enabled for the environment.
 - `created_by` (List of Object) Details of the user that created the environment. (see [below for nested schema](#nestedatt--created_by))
+- `default_provider_configurations` (List of String) List of IDs of provider configurations, used in the environment workspaces by default.
 - `policy_groups` (List of String) List of the environment policy-groups IDs, in the format `pgrp-<RANDOM STRING>`.
 - `status` (String) The status of an environment.
 - `tag_ids` (List of String) List of tag IDs associated with the environment.

--- a/scalr/data_source_scalr_environment.go
+++ b/scalr/data_source_scalr_environment.go
@@ -83,6 +83,12 @@ func dataSourceScalrEnvironment() *schema.Resource {
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"default_provider_configurations": {
+				Description: "List of IDs of provider configurations, used in the environment workspaces by default.",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 		}}
 }
 
@@ -141,6 +147,15 @@ func dataSourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 	_ = d.Set("policy_groups", policyGroups)
+
+	defaultProviderConfigurations := make([]string, 0)
+	if environment.DefaultProviderConfigurations != nil {
+		for _, provider := range environment.DefaultProviderConfigurations {
+			defaultProviderConfigurations = append(defaultProviderConfigurations, provider.ID)
+		}
+	}
+
+	_ = d.Set("default_provider_configurations", defaultProviderConfigurations)
 
 	var tags []string
 	if len(environment.Tags) != 0 {

--- a/scalr/data_source_scalr_environment_test.go
+++ b/scalr/data_source_scalr_environment_test.go
@@ -50,6 +50,7 @@ func TestAccEnvironmentDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.scalr_environment.test", "created_by.0.full_name"),
 					resource.TestCheckResourceAttrSet("data.scalr_environment.test", "created_by.0.email"),
 					resource.TestCheckResourceAttrSet("data.scalr_environment.test", "created_by.0.username"),
+					resource.TestCheckResourceAttr("data.scalr_environment.test", "default_provider_configurations.#", "0"),
 				),
 			},
 			{


### PR DESCRIPTION
…eScalrEnvironment

### Changelog
* [x] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [x] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
