### PR TITLE
SCALRCORE-30362 API / Provider > Agent pools > Environment relation/attribute is not deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `scalr_iam_team`: fixed `users` attribute behaviour when not set in configuration ([#309](https://github.com/Scalr/terraform-provider-scalr/pull/309))
 
+### Changed
+
+- `scalr_agent_pool`: attribute `environment_id` is deprecated ([#311](https://github.com/Scalr/terraform-provider-scalr/pull/311))
+
 ## [1.9.0] - 2024-02-23
 
 ### Added

--- a/docs/resources/agent_pool.md
+++ b/docs/resources/agent_pool.md
@@ -29,7 +29,7 @@ resource "scalr_agent_pool" "default" {
 ### Optional
 
 - `account_id` (String) ID of the account.
-- `environment_id` (String) ID of the environment.
+- `environment_id` (String, Deprecated) ID of the environment.
 - `vcs_enabled` (Boolean) Indicates whether the VCS support is enabled for agents in the pool.
 
 ### Read-Only

--- a/scalr/resource_scalr_agent_pool.go
+++ b/scalr/resource_scalr_agent_pool.go
@@ -35,12 +35,12 @@ func resourceScalrAgentPool() *schema.Resource {
 				DefaultFunc: scalrAccountIDDefaultFunc,
 				ForceNew:    true,
 			},
-
 			"environment_id": {
 				Description: "ID of the environment.",
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
+				Deprecated:  "The attribute `environment_id` is deprecated.",
 			},
 			"vcs_enabled": {
 				Description: "Indicates whether the VCS support is enabled for agents in the pool.",


### PR DESCRIPTION
### Changelog
* [x] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [x] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
