### PR TITLE
SCALRCORE-32232  Provider > Resource scalr_policy_group with envs > constant drift of envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `data.scalr_environments`: changed type of `ids` attribute from TypeList to TypeSet
+- `data.scalr_environments`: changed type of `ids` attribute from TypeList to TypeSet ([372](https://github.com/Scalr/terraform-provider-scalr/pull/372))
 
 ## [2.2.0] - 2024-11-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `data.scalr_environments`: changed type of `ids` attribute from TypeList to TypeSet
+
 ## [2.2.0] - 2024-11-22
 
 ### Added

--- a/docs/data-sources/environments.md
+++ b/docs/data-sources/environments.md
@@ -42,4 +42,4 @@ data "scalr_environments" "all" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `ids` (List of String) The list of environment IDs, in the format [`env-xxxxxxxxxxx`, `env-yyyyyyyyy`].
+- `ids` (Set of String) The list of environment IDs, in the format [`env-xxxxxxxxxxx`, `env-yyyyyyyyy`].

--- a/scalr/data_source_scalr_environments.go
+++ b/scalr/data_source_scalr_environments.go
@@ -35,7 +35,7 @@ func dataSourceScalrEnvironments() *schema.Resource {
 			},
 			"ids": {
 				Description: "The list of environment IDs, in the format [`env-xxxxxxxxxxx`, `env-yyyyyyyyy`].",
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Computed:    true,
 			},


### PR DESCRIPTION
…ibute from TypeList to TypeSet

### Changelog
* [x] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [x] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
