### PR TITLE
SCALRCORE-34129 Provider > scalr_workspace.run_operation_timeout produced an unexpected new value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `data.scalr_provider_configuration` not populating the `name` attribute ([#399](https://github.com/Scalr/terraform-provider-scalr/pull/399))
+- `scalr_workspace`: issue with `run_operation_timeout` attribute causing "provider produced an unexpected new value" error on resource update ([#401](https://github.com/Scalr/terraform-provider-scalr/pull/401))
 
 ### Required
 

--- a/internal/provider/workspace_resource.go
+++ b/internal/provider/workspace_resource.go
@@ -359,7 +359,7 @@ func (r *workspaceResource) Update(ctx context.Context, req resource.UpdateReque
 		opts.Operations = plan.Operations.ValueBoolPointer()
 	}
 
-	if !plan.RunOperationTimeout.Equal(state.RunOperationTimeout) && !plan.RunOperationTimeout.IsNull() {
+	if !plan.RunOperationTimeout.IsNull() {
 		opts.RunOperationTimeout = ptr(int(plan.RunOperationTimeout.ValueInt32()))
 	}
 

--- a/internal/provider/workspace_resource_test.go
+++ b/internal/provider/workspace_resource_test.go
@@ -417,6 +417,35 @@ func TestAccScalrWorkspace_UpgradeFromSDK(t *testing.T) {
 	})
 }
 
+func TestAccScalrWorkspace_SCALRCORE_34129(t *testing.T) {
+	rInt := GetRandomInteger()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: protoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccScalrWorkspace_SCALRCORE_34129(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("scalr_workspace.test", "run_operation_timeout", "30"),
+				),
+			},
+			{
+				Config: testAccScalrWorkspace_SCALRCORE_34129_update1(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("scalr_workspace.test", "run_operation_timeout", "30"),
+				),
+			},
+			{
+				Config: testAccScalrWorkspace_SCALRCORE_34129_update2(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("scalr_workspace.test", "run_operation_timeout"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckScalrWorkspaceExists(
 	n string, workspace *scalr.Workspace) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -1083,4 +1112,45 @@ resource "scalr_workspace" "test" {
     alias = "dev2"
   }
 }`, rInt, defaultAccount))
+}
+
+func testAccScalrWorkspace_SCALRCORE_34129(rInt int) string {
+	return fmt.Sprintf(
+		testAccScalrWorkspaceCommonConfig,
+		rInt,
+		defaultAccount,
+		fmt.Sprintf(`
+resource scalr_workspace test {
+  name                           = "ws-%d"
+  environment_id                 = scalr_environment.test.id
+  run_operation_timeout          = 30
+}`, rInt),
+	)
+}
+
+func testAccScalrWorkspace_SCALRCORE_34129_update1(rInt int) string {
+	return fmt.Sprintf(
+		testAccScalrWorkspaceCommonConfig,
+		rInt,
+		defaultAccount,
+		fmt.Sprintf(`
+resource scalr_workspace test {
+  name                           = "ws-%d-updated"
+  environment_id                 = scalr_environment.test.id
+  run_operation_timeout          = 30
+}`, rInt),
+	)
+}
+
+func testAccScalrWorkspace_SCALRCORE_34129_update2(rInt int) string {
+	return fmt.Sprintf(
+		testAccScalrWorkspaceCommonConfig,
+		rInt,
+		defaultAccount,
+		fmt.Sprintf(`
+resource scalr_workspace test {
+  name                           = "ws-%d"
+  environment_id                 = scalr_environment.test.id
+}`, rInt),
+	)
 }


### PR DESCRIPTION
### Changelog
* [x] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [ ] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
