### PR TITLE
SCALRCORE-34714 Scalr provider > Data 'scalr_environments' searched b…

### DIFF
--- a/internal/provider/environments_data_source.go
+++ b/internal/provider/environments_data_source.go
@@ -98,7 +98,7 @@ func (d *environmentsDataSource) Read(ctx context.Context, req datasource.ReadRe
 
 	id := strings.Builder{} // holds the string to build a unique resource id hash
 	id.WriteString(accID)
-	ids := make([]string, 0)
+	uniqueIDs := make(map[string]struct{})
 
 	opts := scalr.EnvironmentListOptions{
 		Filter: &scalr.EnvironmentFilter{
@@ -130,13 +130,18 @@ func (d *environmentsDataSource) Read(ctx context.Context, req datasource.ReadRe
 		}
 
 		for _, e := range el.Items {
-			ids = append(ids, e.ID)
+			uniqueIDs[e.ID] = struct{}{}
 		}
 
 		if el.CurrentPage >= el.TotalPages {
 			break
 		}
 		opts.PageNumber = el.NextPage
+	}
+
+	ids := make([]string, 0, len(uniqueIDs))
+	for id := range uniqueIDs {
+		ids = append(ids, id)
 	}
 
 	cfg.Id = types.StringValue(fmt.Sprintf("%d", framework.HashString(id.String())))


### PR DESCRIPTION
…y 'account_id' fails if 100 envs already exists

### Changelog
* [ ] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [ ] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
