### PR TITLE
SCALRCORE-35338 The scalr_wokspace_ids data source must request only those attributes it uses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `scalr_wokspace_ids` data source must request only those attributes it uses. ([#437](https://github.com/Scalr/terraform-provider-scalr/pull/437))
+
 ## [3.4.0] - 2025-07-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
 - `scalr_wokspace_ids` data source must request only those attributes it uses. ([#437](https://github.com/Scalr/terraform-provider-scalr/pull/437))
 
 ## [3.4.0] - 2025-07-11

--- a/docs/data-sources/workspace_ids.md
+++ b/docs/data-sources/workspace_ids.md
@@ -35,4 +35,4 @@ data "scalr_workspace_ids" "all" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `ids` (Map of String) A map of workspace names and their opaque IDs, in the format `env_id/name`.
+- `ids` (Map of String) A map of workspace names and their opaque IDs, in the format `id/name`.

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0
 	github.com/hashicorp/terraform-plugin-testing v1.11.0
 	github.com/hashicorp/terraform-svchost v0.1.1
-	github.com/scalr/go-scalr v0.0.0-20250709084620-8b3fc4d46833
+	github.com/scalr/go-scalr v0.0.0-20250712001519-9f42032f4be3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,8 @@ github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3V
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
 github.com/scalr/go-scalr v0.0.0-20250709084620-8b3fc4d46833 h1:ecfQzig7ry0tSQEPo5/dIG8kLP3qjWeI6MpKt5lppnY=
 github.com/scalr/go-scalr v0.0.0-20250709084620-8b3fc4d46833/go.mod h1:Om3UIkHGeOcUK72OzjWI1GlS/hFyY8RRLxgbO0ZPsn4=
+github.com/scalr/go-scalr v0.0.0-20250712001519-9f42032f4be3 h1:adgID8xOmBR3uu7gpUo0mZlzNEkhpsQkPdPfCDwSIsw=
+github.com/scalr/go-scalr v0.0.0-20250712001519-9f42032f4be3/go.mod h1:Om3UIkHGeOcUK72OzjWI1GlS/hFyY8RRLxgbO0ZPsn4=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/internal/provider/data_source_scalr_workspace_ids.go
+++ b/internal/provider/data_source_scalr_workspace_ids.go
@@ -30,7 +30,7 @@ func dataSourceScalrWorkspaceIDs() *schema.Resource {
 			},
 
 			"ids": {
-				Description: "A map of workspace names and their opaque IDs, in the format `env_id/name`.",
+				Description: "A map of workspace names and their opaque IDs, in the format `id/name`.",
 				Type:        schema.TypeMap,
 				Computed:    true,
 			},
@@ -57,6 +57,7 @@ func dataSourceScalrWorkspaceIDsRead(ctx context.Context, d *schema.ResourceData
 
 	options := scalr.WorkspaceListOptions{
 		Filter: &scalr.WorkspaceFilter{Environment: &environmentID},
+		Fields: &scalr.WorkspaceSparseFields{Workspaces: "id,name"},
 	}
 	for {
 		wl, err := scalrClient.Workspaces.List(ctx, options)

--- a/internal/provider/data_source_scalr_workspace_test.go
+++ b/internal/provider/data_source_scalr_workspace_test.go
@@ -39,7 +39,7 @@ func TestAccScalrWorkspaceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.scalr_workspace.test", "auto_apply", "true"),
 					resource.TestCheckResourceAttr(
-						"data.scalr_workspace.test", "terraform_version", "1.1.9"),
+						"data.scalr_workspace.test", "terraform_version", "1.5.7"),
 					resource.TestCheckResourceAttr(
 						"data.scalr_workspace.test", "iac_platform", "terraform"),
 					resource.TestCheckResourceAttr(
@@ -118,7 +118,7 @@ resource scalr_workspace test {
   name                  = "workspace-test-%[1]d"
   environment_id 		= scalr_environment.test.id
   auto_apply            = true
-  terraform_version     = "1.1.9"
+  terraform_version     = "1.5.7"
   iac_platform          = "terraform"
   working_directory     = "terraform/test"
   type                  = "production"

--- a/internal/provider/workspace_resource_test.go
+++ b/internal/provider/workspace_resource_test.go
@@ -176,7 +176,7 @@ func TestAccScalrWorkspace_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"scalr_workspace.test", "execution_mode", string(scalr.WorkspaceExecutionModeLocal)),
 					resource.TestCheckResourceAttr(
-						"scalr_workspace.test", "terraform_version", "1.1.9"),
+						"scalr_workspace.test", "terraform_version", "1.5.7"),
 					resource.TestCheckResourceAttr(
 						"scalr_workspace.test", "iac_platform", string(scalr.WorkspaceIaCPlatformTerraform)),
 					resource.TestCheckResourceAttr(
@@ -217,7 +217,7 @@ func TestAccScalrWorkspace_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"scalr_workspace.test", "execution_mode", string(scalr.WorkspaceExecutionModeLocal)),
 					resource.TestCheckResourceAttr(
-						"scalr_workspace.test", "terraform_version", "1.1.9"),
+						"scalr_workspace.test", "terraform_version", "1.5.7"),
 					resource.TestCheckResourceAttr(
 						"scalr_workspace.test", "iac_platform", string(scalr.WorkspaceIaCPlatformTerraform)),
 					resource.TestCheckResourceAttr(
@@ -525,7 +525,7 @@ func testAccCheckScalrWorkspaceAttributesUpdated(
 			return fmt.Errorf("Bad execution mode: %s", workspace.ExecutionMode)
 		}
 
-		if workspace.TerraformVersion != "1.1.9" {
+		if workspace.TerraformVersion != "1.5.7" {
 			return fmt.Errorf("Bad Terraform version: %s", workspace.TerraformVersion)
 		}
 
@@ -757,7 +757,7 @@ resource "scalr_workspace" "test" {
   environment_id 		        = scalr_environment.test.id
   auto_apply                    = false
   execution_mode                = "%s"
-  terraform_version             = "1.1.9"
+  terraform_version             = "1.5.7"
   working_directory             = "terraform/test"
   run_operation_timeout         = 200
   deletion_protection_enabled   = true
@@ -782,7 +782,7 @@ resource "scalr_workspace" "test" {
   environment_id 		= scalr_environment.test.id
   auto_apply            = false
   execution_mode        = "%s"
-  terraform_version     = "1.1.9"
+  terraform_version     = "1.5.7"
   working_directory     = "terraform/test"
   vcs_repo {
    identifier = "TestRepo/local"
@@ -800,7 +800,7 @@ resource "scalr_workspace" "test" {
   environment_id 		= scalr_environment.test.id
   auto_apply            = false
   execution_mode        = "%s"
-  terraform_version     = "1.1.9"
+  terraform_version     = "1.5.7"
   working_directory     = "terraform/test"
   vcs_provider_id	    = "test_provider_id"
 }`, scalr.WorkspaceExecutionModeLocal),
@@ -815,7 +815,7 @@ resource "scalr_workspace" "test" {
   environment_id 		= scalr_environment.test.id
   auto_apply            = false
   execution_mode        = "%s"
-  terraform_version     = "1.1.9"
+  terraform_version     = "1.5.7"
   working_directory     = "terraform/test"
 }`, scalr.WorkspaceExecutionModeLocal),
 	)
@@ -829,7 +829,7 @@ resource "scalr_workspace" "test" {
   environment_id 		= scalr_environment.test.id
   auto_apply            = false
   execution_mode        = "%s"
-  terraform_version     = "1.1.9"
+  terraform_version     = "1.5.7"
   working_directory     = ""
   hooks {
     pre_init   = "./scripts/pre-init_updated.sh"


### PR DESCRIPTION
Provider utilizes the filter[workspaces] sparse field to request only specific attributes or relationships from a resource, rather than the entire set of data.

### Changelog
* [x] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [x] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
