### PR TITLE
SCALRCORE-35491 - Provider > agent_pool resource > account_id deprication warning even when not used in configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `scalr_wokspace_ids` data source must request only those attributes it uses. ([#437](https://github.com/Scalr/terraform-provider-scalr/pull/437))
+- `scalr_agent_pool`: warning misfire for attribute `account_id`. ([#443](https://github.com/Scalr/terraform-provider-scalr/pull/443))
 
 ### Added
 

--- a/internal/provider/resource_scalr_role.go
+++ b/internal/provider/resource_scalr_role.go
@@ -43,7 +43,6 @@ func resourceScalrRole() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				DefaultFunc: scalrAccountIDDefaultFunc,
 				ForceNew:    true,
 				Deprecated: "Attribute `account_id` is deprecated, the account id is calculated from the " +
 					"API request context.",


### PR DESCRIPTION
### Changelog
* [ ] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [ ] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
