### PR TITLE
SCALRCORE-35491 - Provider > scalr_role resource > account_id deprication warning even when not used in configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `scalr_wokspace_ids` data source must request only those attributes it uses. ([#437](https://github.com/Scalr/terraform-provider-scalr/pull/437))
-- `scalr_agent_pool`: warning misfire for attribute `account_id`. ([#443](https://github.com/Scalr/terraform-provider-scalr/pull/443))
+- `scalr_role`: warning misfire for attribute `account_id`. ([#443](https://github.com/Scalr/terraform-provider-scalr/pull/443))
 
 ### Added
 


### PR DESCRIPTION
### Changelog
* [ ] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [ ] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
