### PR TITLE
SCALRCORE-35943 [Provider] scalr_role resource > Resource changes are…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
 - The `claim_condition.operator` attribute in the `scalr_assume_service_account_policy` resource accepts `like` which can be used for shell-style wilcard patterns. ([#461](https://github.com/Scalr/terraform-provider-scalr/pull/461))
+
+### Fixed
+
+- `scalr_role`: false positive diffs when `permissions` in the configuration contain duplicates. ([#462](https://github.com/Scalr/terraform-provider-scalr/pull/462))
 
 ## [3.8.0] - 2025-09-02
 


### PR DESCRIPTION
… shown even there are no any updates

### Changelog
* [x] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [ ] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
