### PR TITLE
SCALRCORE-38354 (2) Provider > scalr_iam_team without users fails when SCIM provisioned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.16.1] - 2026-05-01
+## [3.16.2] - 2026-05-05
 
 ### Fixed
 
@@ -1206,7 +1206,8 @@ Requires Scalr 8.0.1-beta.20200625 at least
 
 - Initial release.
 
-[Unreleased]: https://github.com/Scalr/terraform-provider-scalr/compare/v3.16.1...HEAD
+[Unreleased]: https://github.com/Scalr/terraform-provider-scalr/compare/v3.16.2...HEAD
+[3.16.2]: https://github.com/Scalr/terraform-provider-scalr/releases/tag/v3.16.2
 [3.16.1]: https://github.com/Scalr/terraform-provider-scalr/releases/tag/v3.16.1
 [3.16.0]: https://github.com/Scalr/terraform-provider-scalr/releases/tag/v3.16.0
 [3.15.0]: https://github.com/Scalr/terraform-provider-scalr/releases/tag/v3.15.0

--- a/internal/provider/iam_team_resource.go
+++ b/internal/provider/iam_team_resource.go
@@ -201,7 +201,13 @@ func (r *iamTeamResource) Create(ctx context.Context, req resource.CreateRequest
 	var priorUsers *types.Set
 	if iamTeam.Relationships.IdentityProvider != nil &&
 		iamTeam.Relationships.IdentityProvider.Attributes.IdpType != schemas.IdentityProviderIdpTypeScalr {
-		priorUsers = &plan.Users
+		users := plan.Users
+		if users.IsUnknown() {
+			// `users` attribute was not set in config, and there is no prior state (new resource):
+			// store an empty set so UseStateForUnknown can preserve it on subsequent plans.
+			users = types.SetValueMust(types.StringType, nil)
+		}
+		priorUsers = &users
 	}
 
 	result, diags := iamTeamResourceModelFromAPI(ctx, iamTeam, priorUsers)
@@ -294,7 +300,11 @@ func (r *iamTeamResource) Update(ctx context.Context, req resource.UpdateRequest
 	var priorUsers *types.Set
 	if iamTeam.Relationships.IdentityProvider != nil &&
 		iamTeam.Relationships.IdentityProvider.Attributes.IdpType != schemas.IdentityProviderIdpTypeScalr {
-		priorUsers = &plan.Users
+		users := plan.Users
+		if users.IsUnknown() {
+			users = state.Users
+		}
+		priorUsers = &users
 	}
 
 	result, diags := iamTeamResourceModelFromAPI(ctx, iamTeam, priorUsers)
@@ -326,9 +336,9 @@ func (r *iamTeamResource) ModifyPlan(
 	resp *resource.ModifyPlanResponse,
 ) {
 	// Fetch the account with its identity provider;
-	// issue a warning if it's an external IDP and the `users` attribute is set.
+	// issue a warning if it's an external IDP and the `users` attribute is set in config.
 	var users types.Set
-	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("users"), &users)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("users"), &users)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/iam_team_resource_test.go
+++ b/internal/provider/iam_team_resource_test.go
@@ -112,6 +112,36 @@ func TestAccScalrIamTeamResource_import(t *testing.T) {
 	)
 }
 
+func TestAccScalrIamTeamResource_noUsers(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-team")
+
+	resource.Test(
+		t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV5ProviderFactories: protoV5ProviderFactories(t),
+			CheckDestroy:             testAccCheckScalrIamTeamResourceDestroy,
+			Steps: []resource.TestStep{
+				// Create without users: state must resolve to an empty set, not unknown.
+				{
+					Config: testAccScalrIamTeamResourceNoUsers(name),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("scalr_iam_team.test", "users.#", "0"),
+					),
+				},
+				// Subsequent plan must be empty (UseStateForUnknown)
+				{
+					Config: testAccScalrIamTeamResourceNoUsers(name),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectEmptyPlan(),
+						},
+					},
+				},
+			},
+		},
+	)
+}
+
 func TestAccScalrIamTeamResource_UpgradeFromSDK(t *testing.T) {
 	name := acctest.RandomWithPrefix("test-team")
 
@@ -131,6 +161,37 @@ func TestAccScalrIamTeamResource_UpgradeFromSDK(t *testing.T) {
 				{
 					ProtoV5ProviderFactories: protoV5ProviderFactories(t),
 					Config:                   testAccScalrIamTeamResourceBasic(name),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectEmptyPlan(),
+						},
+					},
+				},
+			},
+		},
+	)
+}
+
+func TestAccScalrIamTeamResource_UpgradeFromSDK_noUsers(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-team")
+
+	resource.Test(
+		t, resource.TestCase{
+			Steps: []resource.TestStep{
+				// Create with old SDK, no users in config.
+				{
+					ExternalProviders: map[string]resource.ExternalProvider{
+						"scalr": {
+							Source:            "registry.scalr.io/scalr/scalr",
+							VersionConstraint: "<=3.15.0",
+						},
+					},
+					Config: testAccScalrIamTeamResourceNoUsers(name),
+					Check:  resource.TestCheckResourceAttrSet("scalr_iam_team.test", "id"),
+				},
+				{
+					ProtoV5ProviderFactories: protoV5ProviderFactories(t),
+					Config:                   testAccScalrIamTeamResourceNoUsers(name),
 					ConfigPlanChecks: resource.ConfigPlanChecks{
 						PreApply: []plancheck.PlanCheck{
 							plancheck.ExpectEmptyPlan(),
@@ -207,6 +268,16 @@ resource "scalr_iam_team" "test" {
   description = "updated"
   account_id  = "%s"
   users       = []
+}`, name, defaultAccount,
+	)
+}
+
+func testAccScalrIamTeamResourceNoUsers(name string) string {
+	return fmt.Sprintf(
+		`
+resource "scalr_iam_team" "test" {
+  name       = "%s"
+  account_id = "%s"
 }`, name, defaultAccount,
 	)
 }


### PR DESCRIPTION
### Changelog
* [x] I have updated CHANGELOG.md according to [CONTRIBUTING.md](../CONTRIBUTING.md)

### Documentation
* [ ] I have updated resource/data source documentation in [docs](../docs)

### State
* [ ] My changes affect the state
* [ ] I have included a state migration and a unit test for it
