### PR TITLE
Fix: add missing import support for scalr_run_trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `scalr_run_trigger`: add missing import support
+
 ## [3.16.2] - 2026-05-05
 
 ### Fixed

--- a/internal/provider/resource_scalr_run_triggers.go
+++ b/internal/provider/resource_scalr_run_triggers.go
@@ -22,6 +22,9 @@ func resourceScalrRunTrigger() *schema.Resource {
 		CreateContext: resourceScalrRunTriggerCreate,
 		DeleteContext: resourceScalrRunTriggerDelete,
 		ReadContext:   resourceScalrRunTriggerRead,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"downstream_id": {

--- a/internal/provider/resource_scalr_run_triggers_test.go
+++ b/internal/provider/resource_scalr_run_triggers_test.go
@@ -25,6 +25,11 @@ func TestAccScalrRunTriggersDataSource_basic(t *testing.T) {
 					testAccCheckRunTriggerAttributes(runTrigger, "scalr_environment.test"),
 				),
 			},
+			{
+				ResourceName:      "scalr_run_trigger.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Summary

The `scalr_run_trigger` resource documentation and examples already describe import support, but the resource implementation was missing the `Importer` field. This PR adds the standard SDKv2 passthrough importer and an acceptance test import verification step.

## Changes

- **`internal/provider/resource_scalr_run_triggers.go`**: added `Importer: &schema.ResourceImporter{StateContext: schema.ImportStatePassthroughContext}`
- **`internal/provider/resource_scalr_run_triggers_test.go`**: added `ImportState` + `ImportStateVerify` step to existing acceptance test
- **`CHANGELOG.md`**: added `[Unreleased]` entry under `### Fixed`

## Verification

The fix follows the exact SDKv2 import pattern already used by other resources in this provider (e.g., `scalr_access_policy`, `scalr_agent_pool`, `scalr_event_bridge_integration`).

`ImportStatePassthroughContext` is sufficient because `ReadContext` already fetches `downstream_id` and `upstream_id` from the API using the run trigger ID.

Fixes #528