### PR TITLE
SCALRCORE-39813 Quote run_post_relese workflow-dispatch input 🤖🤖🤖

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,6 @@ jobs:
               inputs: {
                 version: providerVersion,
                 registry: 'prod',
-                run_post_relese: true
+                run_post_relese: 'true'
               }
             })


### PR DESCRIPTION
## Why

Context: [slack link](https://scalr.slack.com/archives/C05FE3TT74L/p1787305109851279?thread_ts=1787219599.544859&cid=C05FE3TT74L)

The "Trigger E2E Tests" job fails with `422 — Invalid value for input 'run_post_relese'` when it dispatches `e2e-provider-release.yml` in Scalr/fatmouse. The GitHub API accepts only string values for workflow-dispatch inputs, and the job sends a JSON boolean. As a result, no e2e run starts after a provider release (seen on v3.19.0: https://github.com/Scalr/terraform-provider-scalr/actions/runs/32462373100/job/96730622646).

## Changes

Quote the value: `run_post_relese: 'true'`. The `relese` typo stays — it matches the input name declared in fatmouse.